### PR TITLE
Efficient state

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Test
         run: |
+          cargo clippy
           cargo test
     
       - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ resolver = "2"
 
 [workspace.dependencies]
 # Serialization and Deserialization
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["rc", "derive"] }

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ class BehaviorTree {
 
 Behavior --> Action: Implements
 
-Action --> Child: Contains
+Child --> Action: Contains
 
 BehaviorTree --> Action: Implements
-Child --> BehaviorTree: Contains
+BehaviorTree --> Child: Contains
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # behaviortree-rs
+
+```mermaid
+classDiagram
+
+class Behavior~A~ {
+    <<enum>>
+}
+
+class Action~S~ {
+    <<trait>>
+    tick(&mut self, delta: f64, shared: &mut S)
+    reset(&mut self)
+    child_state(&mut self) ChildState
+}
+
+
+
+class Child {
+    <<struct>>
+    Box~dyn Action~S~~ action
+}
+
+class BehaviorTree {
+    <<struct>>
+    Child~S~ child
+
+    new(Behavior~A~ behavior) BehaviorTree
+}
+
+Behavior --> Action: Implements
+
+Action --> Child: Contains
+
+BehaviorTree --> Action: Implements
+Child --> BehaviorTree: Contains
+```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ classDiagram
 
 class Behavior~A~ {
     <<enum>>
+    Leaf
+    Decorator
+    Control
 }
 
 class Action~S~ {

--- a/behaviortree/src/behavior.rs
+++ b/behaviortree/src/behavior.rs
@@ -2,7 +2,7 @@
 ///
 /// This is used for more complex event logic.
 /// Can also be used for game AI.
-#[derive(Clone, serde::Deserialize, serde::Serialize, PartialEq)]
+#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Behavior<A> {
     /// A high level description of an action.
     Action(A),

--- a/behaviortree/src/behavior_interface.rs
+++ b/behaviortree/src/behavior_interface.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use crate::{
     behavior_nodes::{InvertState, SelectState, SequenceState, WaitState},
-    Behavior, ChildState, ChildStateInfo, Status,
+    Behavior, ChildState, ChildStateInfo, ChildStateInfoInner, Status,
 };
 
 #[cfg(test)]
@@ -86,7 +86,7 @@ where
 /// - Child State
 pub struct Child<S> {
     action: Box<dyn Action<S>>,
-    state: ChildStateInfo,
+    state: ChildStateInfoInner,
 }
 
 impl<S> Child<S> {
@@ -115,7 +115,7 @@ impl<S> Child<S> {
     }
 
     pub fn child_state_info(&self) -> ChildStateInfo {
-        self.state.clone()
+        ChildStateInfo::from(self.state.clone())
     }
 
     pub fn child_state(&self) -> ChildState {

--- a/behaviortree/src/behavior_interface.rs
+++ b/behaviortree/src/behavior_interface.rs
@@ -40,7 +40,7 @@ pub trait ToAction<S> {
 
 pub fn convert_behaviors<A, S>(mut behaviors: Vec<Behavior<A>>) -> Vec<Child<S>>
 where
-    A: ToAction<S> + 'static,
+    A: ToAction<S>,
     S: 'static,
 {
     behaviors
@@ -54,7 +54,7 @@ where
 
 impl<A, S> From<Behavior<A>> for Box<dyn Action<S>>
 where
-    A: ToAction<S> + 'static,
+    A: ToAction<S>,
     S: 'static,
 {
     fn from(behavior: Behavior<A>) -> Self {

--- a/behaviortree/src/behavior_interface.rs
+++ b/behaviortree/src/behavior_interface.rs
@@ -62,11 +62,6 @@ pub struct Child<S> {
 }
 
 impl<S> Child<S> {
-    pub fn new(action: Box<dyn Action<S>>) -> Self {
-        let state = Rc::new(RefCell::new((action.child_state(), None)));
-        Self { action, state }
-    }
-
     pub fn tick(&mut self, dt: f64, shared: &mut S) -> Status {
         let status = self.action.tick(dt, shared);
         {
@@ -99,6 +94,13 @@ impl<S> Child<S> {
     }
 }
 
+impl<S> From<Box<dyn Action<S>>> for Child<S> {
+    fn from(action: Box<dyn Action<S>>) -> Self {
+        let state = Rc::new(RefCell::new((action.child_state(), None)));
+        Self { action, state }
+    }
+}
+
 impl<A, S> From<Behavior<A>> for Child<S>
 where
     A: ToAction<S>,
@@ -121,7 +123,7 @@ where
                 Box::new(InvertState::new(Self::from(*behavior)))
             }
         };
-        Self::new(action)
+        Self::from(action)
     }
 }
 

--- a/behaviortree/src/behavior_nodes/invert_node.rs
+++ b/behaviortree/src/behavior_nodes/invert_node.rs
@@ -1,4 +1,4 @@
-use crate::{Action, Child, State, Status};
+use crate::{Action, Child, ChildState, State, Status};
 
 pub struct InvertState<S> {
     //
@@ -46,6 +46,10 @@ impl<S> Action<S> for InvertState<S> {
     fn state(&self) -> State {
         let (state, status) = self.child.child_state();
         State::SingleChild(Box::new((state, status)))
+    }
+
+    fn child_state(&self) -> ChildState {
+        ChildState::SingleChild(self.child.child_state_info())
     }
 }
 

--- a/behaviortree/src/behavior_nodes/invert_node.rs
+++ b/behaviortree/src/behavior_nodes/invert_node.rs
@@ -57,7 +57,7 @@ mod tests {
         let mut shared = TestShared::default();
 
         let behavior = Behavior::Action(TestActions::SuccessTimes { ticks: 1 });
-        let mut invert = InvertState::new(Child::new(Box::from(behavior)));
+        let mut invert = InvertState::new(Child::from(behavior));
         assert_eq!(
             invert.child_state(),
             ChildState::SingleChild(ChildStateInfo::from((ChildState::NoChild, None)))
@@ -89,7 +89,7 @@ mod tests {
         let mut shared = TestShared::default();
 
         let behavior = Behavior::Action(TestActions::FailureTimes { ticks: 1 });
-        let mut invert = InvertState::new(Child::new(Box::from(behavior)));
+        let mut invert = InvertState::new(Child::from(behavior));
 
         let status = invert.tick(0.1, &mut shared);
         assert_eq!(status, Status::Success);
@@ -113,7 +113,7 @@ mod tests {
             times: 1,
             output: Status::Failure,
         });
-        let mut invert = InvertState::new(Child::new(Box::from(behavior)));
+        let mut invert = InvertState::new(Child::from(behavior));
 
         let status = invert.tick(0.1, &mut shared);
         assert_eq!(status, Status::Running);
@@ -158,7 +158,7 @@ mod tests {
                 m
             },
         });
-        let mut invert = InvertState::new(Child::new(Box::from(behavior)));
+        let mut invert = InvertState::new(Child::from(behavior));
 
         let status = invert.tick(0.1, &mut shared);
         assert_eq!(status, Status::Failure);

--- a/behaviortree/src/behavior_nodes/invert_node.rs
+++ b/behaviortree/src/behavior_nodes/invert_node.rs
@@ -45,11 +45,9 @@ impl<S> Action<S> for InvertState<S> {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, rc::Rc};
-
     use crate::{
         test_behavior_interface::{TestActions, TestShared},
-        Behavior,
+        Behavior, ChildStateInfo,
     };
 
     use super::*;
@@ -62,27 +60,27 @@ mod tests {
         let mut invert = InvertState::new(Child::new(Box::from(behavior)));
         assert_eq!(
             invert.child_state(),
-            ChildState::SingleChild(Rc::new(RefCell::new((ChildState::NoChild, None))))
+            ChildState::SingleChild(ChildStateInfo::from((ChildState::NoChild, None)))
         );
 
         let status = invert.tick(0.1, &mut shared);
         assert_eq!(status, Status::Failure);
         assert_eq!(
             invert.child_state(),
-            ChildState::SingleChild(Rc::new(RefCell::new((
+            ChildState::SingleChild(ChildStateInfo::from((
                 ChildState::NoChild,
                 Some(Status::Success)
-            ))))
+            )))
         );
 
         let status = invert.tick(0.1, &mut shared);
         assert_eq!(status, Status::Failure);
         assert_eq!(
             invert.child_state(),
-            ChildState::SingleChild(Rc::new(RefCell::new((
+            ChildState::SingleChild(ChildStateInfo::from((
                 ChildState::NoChild,
                 Some(Status::Success)
-            ))))
+            )))
         );
     }
 
@@ -97,10 +95,10 @@ mod tests {
         assert_eq!(status, Status::Success);
         assert_eq!(
             invert.child_state(),
-            ChildState::SingleChild(Rc::new(RefCell::new((
+            ChildState::SingleChild(ChildStateInfo::from((
                 ChildState::NoChild,
                 Some(Status::Failure)
-            ))))
+            )))
         );
 
         let status = invert.tick(0.1, &mut shared);
@@ -121,30 +119,30 @@ mod tests {
         assert_eq!(status, Status::Running);
         assert_eq!(
             invert.child_state(),
-            ChildState::SingleChild(Rc::new(RefCell::new((
+            ChildState::SingleChild(ChildStateInfo::from((
                 ChildState::NoChild,
                 Some(Status::Running)
-            ))))
+            )))
         );
 
         let status = invert.tick(0.1, &mut shared);
         assert_eq!(status, Status::Success);
         assert_eq!(
             invert.child_state(),
-            ChildState::SingleChild(Rc::new(RefCell::new((
+            ChildState::SingleChild(ChildStateInfo::from((
                 ChildState::NoChild,
                 Some(Status::Failure)
-            ))))
+            )))
         );
 
         let status = invert.tick(0.1, &mut shared);
         assert_eq!(status, Status::Success);
         assert_eq!(
             invert.child_state(),
-            ChildState::SingleChild(Rc::new(RefCell::new((
+            ChildState::SingleChild(ChildStateInfo::from((
                 ChildState::NoChild,
                 Some(Status::Failure)
-            ))))
+            )))
         );
     }
 

--- a/behaviortree/src/behavior_nodes/select_node.rs
+++ b/behaviortree/src/behavior_nodes/select_node.rs
@@ -75,8 +75,6 @@ impl<S> Action<S> for SelectState<S> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-
     use crate::{
         convert_behaviors,
         test_behavior_interface::{TestActions, TestShared},
@@ -95,7 +93,7 @@ mod tests {
         let mut shared = TestShared::default();
         let status = select.tick(0.1, &mut shared);
         assert_eq!(status, Status::Success);
-        matches!(select.child_state(), ChildState::MultipleChildren(states) if states.len() == 1 && states[0] == Rc::new(RefCell::new((ChildState::NoChild, Some(Status::Success)))));
+        matches!(select.child_state(), ChildState::MultipleChildren(states) if states.len() == 1 && states[0] == ChildStateInfo::from((ChildState::NoChild, Some(Status::Success))));
 
         let status = select.tick(0.1, &mut shared);
         assert_eq!(status, Status::Success);

--- a/behaviortree/src/behavior_nodes/sequence_node.rs
+++ b/behaviortree/src/behavior_nodes/sequence_node.rs
@@ -75,8 +75,6 @@ impl<S> Action<S> for SequenceState<S> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-
     use super::*;
     use crate::{
         convert_behaviors,
@@ -95,7 +93,7 @@ mod tests {
         let status = sequence.tick(0.1, &mut shared);
         assert_eq!(status, Status::Success);
         assert_eq!(sequence.status, Some(Status::Success));
-        matches!(sequence.child_state(), ChildState::MultipleChildren(states) if states.len() == 1 && states[0] == Rc::new(RefCell::new((ChildState::NoChild, Some(Status::Success)))));
+        matches!(sequence.child_state(), ChildState::MultipleChildren(states) if states.len() == 1 && states[0] == ChildStateInfo::from((ChildState::NoChild, Some(Status::Success))));
 
         let status = sequence.tick(0.1, &mut shared);
         assert_eq!(status, Status::Success);

--- a/behaviortree/src/behavior_tree.rs
+++ b/behaviortree/src/behavior_tree.rs
@@ -51,8 +51,7 @@ impl<A, S> BehaviorTree<A, S> {
         A: ToAction<S> + Clone,
         S: 'static,
     {
-        let action: Box<dyn Action<S>> = Box::from(behavior.clone());
-        let child = Child::new(action);
+        let child = Child::from(behavior.clone());
         Self {
             behavior,
             behavior_policy,

--- a/behaviortree/src/behavior_tree.rs
+++ b/behaviortree/src/behavior_tree.rs
@@ -48,7 +48,7 @@ impl<A, S> Action<S> for BehaviorTree<A, S> {
 impl<A, S> BehaviorTree<A, S> {
     pub fn new(behavior: Behavior<A>, behavior_policy: BehaviorTreePolicy) -> Self
     where
-        A: ToAction<S> + Clone + 'static,
+        A: ToAction<S> + Clone,
         S: 'static,
     {
         let action: Box<dyn Action<S>> = Box::from(behavior.clone());

--- a/behaviortree/src/behavior_tree.rs
+++ b/behaviortree/src/behavior_tree.rs
@@ -1,4 +1,4 @@
-use crate::{Action, Behavior, State, Status, ToAction};
+use crate::{Action, Behavior, ChildState, State, Status, ToAction};
 
 pub enum BehaviorTreePolicy {
     /// Resets/Reloads the behavior tree once it is completed
@@ -47,6 +47,10 @@ impl<A, S> Action<S> for BehaviorTree<A, S> {
     fn state(&self) -> State {
         self.action.state()
     }
+
+    fn child_state(&self) -> ChildState {
+        self.action.child_state()
+    }
 }
 
 impl<A, S> BehaviorTree<A, S> {
@@ -66,11 +70,11 @@ impl<A, S> BehaviorTree<A, S> {
 
     pub fn tick_with_observer<O>(&mut self, dt: f64, shared: &mut S, observer: &mut O) -> Status
     where
-        O: FnMut(State, Status),
+        O: FnMut(ChildState, Status),
     {
         let status = self.tick(dt, shared);
-        let state = self.state();
-        observer(state, status);
+        let child_state = self.child_state();
+        observer(child_state, status);
         status
     }
 
@@ -180,8 +184,8 @@ mod tests {
         let mut tree = BehaviorTree::new(behavior, BehaviorTreePolicy::RetainOnCompletion);
 
         let mut shared = TestShared::default();
-        let mut observer = |state: State, status: Status| {
-            println!("Status: {:?}, State: {:#?}", status, state);
+        let mut observer = |state, status| {
+            println!("Status: {:?}, State: {:?}", status, state);
         };
 
         let status = tree.tick_with_observer(0.1, &mut shared, &mut observer);

--- a/behaviortree/src/state.rs
+++ b/behaviortree/src/state.rs
@@ -1,15 +1,26 @@
+use std::{cell::RefCell, rc::Rc};
+
 use crate::Status;
 
-pub type ChildState = (State, Option<Status>);
-
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq)]
+pub type StateInfo = (State, Option<Status>);
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
 pub enum State {
-    // Leaf nodes
+    /// Leaf nodes
     NoChild,
+    /// Decorator nodes
+    SingleChild(Box<StateInfo>),
+    /// Control nodes
+    MultipleChildren(Vec<StateInfo>),
+}
 
-    // Decorator nodes
-    SingleChild(Box<ChildState>),
+pub type ChildStateInfo = Rc<RefCell<(ChildState, Option<Status>)>>;
 
-    // Control nodes
-    MultipleChildren(Vec<ChildState>),
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum ChildState {
+    /// Leaf nodes
+    NoChild,
+    /// Decorator nodes
+    SingleChild(ChildStateInfo),
+    /// Control nodes
+    MultipleChildren(Rc<[ChildStateInfo]>),
 }

--- a/behaviortree/src/state.rs
+++ b/behaviortree/src/state.rs
@@ -2,17 +2,6 @@ use std::{cell::RefCell, rc::Rc};
 
 use crate::Status;
 
-pub type StateInfo = (State, Option<Status>);
-#[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
-pub enum State {
-    /// Leaf nodes
-    NoChild,
-    /// Decorator nodes
-    SingleChild(Box<StateInfo>),
-    /// Control nodes
-    MultipleChildren(Vec<StateInfo>),
-}
-
 pub type ChildStateInfo = Rc<RefCell<(ChildState, Option<Status>)>>;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/behaviortree/src/state.rs
+++ b/behaviortree/src/state.rs
@@ -1,8 +1,32 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{
+    cell::{Ref, RefCell},
+    rc::Rc,
+};
 
 use crate::Status;
 
-pub type ChildStateInfo = Rc<RefCell<(ChildState, Option<Status>)>>;
+pub type ChildStateInfoInner = Rc<RefCell<(ChildState, Option<Status>)>>;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ChildStateInfo(ChildStateInfoInner);
+
+impl From<ChildStateInfoInner> for ChildStateInfo {
+    fn from(inner: ChildStateInfoInner) -> Self {
+        Self(inner)
+    }
+}
+
+impl From<(ChildState, Option<Status>)> for ChildStateInfo {
+    fn from(inner: (ChildState, Option<Status>)) -> Self {
+        Self(Rc::new(RefCell::new(inner)))
+    }
+}
+
+impl ChildStateInfo {
+    pub fn get(&self) -> Ref<'_, (ChildState, Option<Status>)> {
+        self.0.borrow()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ChildState {

--- a/behaviortree/src/status.rs
+++ b/behaviortree/src/status.rs
@@ -1,5 +1,5 @@
 /// The result of a behavior or action.
-#[derive(Copy, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq, Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Status {
     /// The behavior or action succeeded.
     Success,


### PR DESCRIPTION
- Use Rc instead of Box
- Use Rc<[]> instead of Vec
- Constrain ChildStateInfo for read-only access
- Rename State to ChildState