### PR TITLE
AsyncBehaviorTree Observer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["behaviortree", "async_behaviortree"]
+members = ["behaviortree_common", "behaviortree", "async_behaviortree"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/async_behaviortree/Cargo.toml
+++ b/async_behaviortree/Cargo.toml
@@ -18,3 +18,5 @@ tokio = { version = "1.38.0", default-features = false, features = [
 
 [dev-dependencies]
 ticked_async_executor = { git = "https://github.com/coder137/ticked-async-executor", rev = "45c76da3730e0f77f08c9f6af86f00832c89fe1e" }
+
+tokio-stream = { version = "0.1.15", features = ["full"] }

--- a/async_behaviortree/src/async_behavior_interface.rs
+++ b/async_behaviortree/src/async_behavior_interface.rs
@@ -16,7 +16,7 @@ pub trait AsyncAction<S> {
     /// Resets the current action to its initial/newly created state
     ///
     /// Decorator and Control nodes need to also reset their ticked children
-    fn reset(&mut self);
+    fn reset(&mut self, shared: &mut S);
 }
 
 pub trait ToAsyncAction<S> {
@@ -92,7 +92,7 @@ pub mod test_async_behavior_interface {
             self.status
         }
 
-        fn reset(&mut self) {
+        fn reset(&mut self, _shared: &mut S) {
             self.elapsed = 0;
         }
     }

--- a/async_behaviortree/src/async_behavior_interface.rs
+++ b/async_behaviortree/src/async_behavior_interface.rs
@@ -1,7 +1,4 @@
-use crate::{
-    behavior_nodes::{AsyncInvertState, AsyncSelectState, AsyncSequenceState, AsyncWaitState},
-    Behavior, Status,
-};
+use crate::AsyncChild;
 
 #[async_trait::async_trait(?Send)]
 pub trait AsyncAction<S> {
@@ -26,77 +23,28 @@ pub trait ToAsyncAction<S> {
     fn to_async_action(self) -> Box<dyn AsyncAction<S>>;
 }
 
-pub struct AsyncChild<S> {
-    action: Box<dyn AsyncAction<S>>,
-    status: Option<Status>,
-}
-
-impl<S> AsyncChild<S> {
-    pub fn from_behavior<A>(behavior: Behavior<A>) -> Self
-    where
-        A: ToAsyncAction<S>,
-        S: 'static,
-    {
-        let action = match behavior {
-            Behavior::Action(action) => action.to_async_action(),
-            Behavior::Wait(target) => Box::new(AsyncWaitState::new(target)),
-            Behavior::Invert(behavior) => {
-                let child = Self::from_behavior(*behavior);
-                Box::new(AsyncInvertState { child })
-            }
-            Behavior::Sequence(behaviors) => {
-                let children = Self::from_behaviors(behaviors);
-                Box::new(AsyncSequenceState { children })
-            }
-            Behavior::Select(behaviors) => {
-                let children = Self::from_behaviors(behaviors);
-                Box::new(AsyncSelectState { children })
-            }
-        };
-        Self::from_action(action)
-    }
-
-    pub fn from_behaviors<A>(mut behaviors: Vec<Behavior<A>>) -> Vec<Self>
-    where
-        A: ToAsyncAction<S>,
-        S: 'static,
-    {
-        behaviors
-            .drain(..)
-            .map(|behavior| Self::from_behavior(behavior))
-            .collect()
-    }
-
-    pub async fn run(
+#[async_trait::async_trait(?Send)]
+pub trait AsyncDecorator<S> {
+    async fn run(
         &mut self,
+        child: &mut AsyncChild<S>,
         delta: &mut tokio::sync::watch::Receiver<f64>,
         shared: &mut S,
-    ) -> bool {
-        self.status = Some(Status::Running);
-        let success = self.action.run(delta, shared).await;
-        let status = if success {
-            Status::Success
-        } else {
-            Status::Failure
-        };
-        self.status = Some(status);
-        success
-    }
+    ) -> bool;
 
-    pub fn reset(&mut self) {
-        if self.status.is_none() {
-            return;
-        }
-        self.action.reset();
-        self.status = None;
-    }
+    fn reset(&mut self);
+}
 
-    fn from_action(action: Box<dyn AsyncAction<S>>) -> Self {
-        Self {
-            action,
-            status: None,
-        }
-    }
+#[async_trait::async_trait(?Send)]
+pub trait AsyncControl<S> {
+    async fn run(
+        &mut self,
+        children: &mut [AsyncChild<S>],
+        delta: &mut tokio::sync::watch::Receiver<f64>,
+        shared: &mut S,
+    ) -> bool;
+
+    fn reset(&mut self);
 }
 
 #[cfg(test)]
@@ -105,7 +53,7 @@ pub mod test_async_behavior_interface {
 
     pub const DELTA: f64 = 1000.0 / 60.0;
 
-    #[derive(Default)]
+    #[derive(Debug, Default)]
     pub struct TestShared;
 
     struct GenericTestAction {

--- a/async_behaviortree/src/async_behaviortree.rs
+++ b/async_behaviortree/src/async_behaviortree.rs
@@ -65,7 +65,7 @@ impl AsyncBehaviorTree {
                         match behavior_policy {
                             AsyncBehaviorTreePolicy::ReloadOnCompletion => {
                                 async_std::task::yield_now().await;
-                                child.reset();
+                                child.reset(&mut shared);
                             },
                             AsyncBehaviorTreePolicy::RetainOnCompletion => {
                                 break;
@@ -80,7 +80,7 @@ impl AsyncBehaviorTree {
                         match message {
                             BehaviorControllerMessage::Reset => {
                                 async_std::task::yield_now().await;
-                                child.reset();
+                                child.reset(&mut shared);
                                 match behavior_policy {
                                     AsyncBehaviorTreePolicy::ReloadOnCompletion => {},
                                     AsyncBehaviorTreePolicy::RetainOnCompletion => {
@@ -89,7 +89,7 @@ impl AsyncBehaviorTree {
                                 }
                             },
                             BehaviorControllerMessage::Shutdown => {
-                                child.reset();
+                                child.reset(&mut shared);
                                 break;
                             },
                         }

--- a/async_behaviortree/src/async_behaviortree.rs
+++ b/async_behaviortree/src/async_behaviortree.rs
@@ -63,8 +63,13 @@ impl AsyncBehaviorTree {
                 tokio::select! {
                     _ = child.run(&mut delta, &mut shared) => {
                         match behavior_policy {
-                            AsyncBehaviorTreePolicy::ReloadOnCompletion => {child.reset();},
-                            AsyncBehaviorTreePolicy::RetainOnCompletion => {break;},
+                            AsyncBehaviorTreePolicy::ReloadOnCompletion => {
+                                async_std::task::yield_now().await;
+                                child.reset();
+                            },
+                            AsyncBehaviorTreePolicy::RetainOnCompletion => {
+                                break;
+                            },
                         }
                     }
                     message = message_rx.recv() => {
@@ -74,10 +79,13 @@ impl AsyncBehaviorTree {
                         };
                         match message {
                             BehaviorControllerMessage::Reset => {
+                                async_std::task::yield_now().await;
                                 child.reset();
                                 match behavior_policy {
                                     AsyncBehaviorTreePolicy::ReloadOnCompletion => {},
-                                    AsyncBehaviorTreePolicy::RetainOnCompletion => {break;},
+                                    AsyncBehaviorTreePolicy::RetainOnCompletion => {
+                                        break;
+                                    },
                                 }
                             },
                             BehaviorControllerMessage::Shutdown => {

--- a/async_behaviortree/src/async_child.rs
+++ b/async_behaviortree/src/async_child.rs
@@ -92,21 +92,21 @@ impl<S> AsyncChild<S> {
         success
     }
 
-    pub fn reset(&mut self) {
+    pub fn reset(&mut self, shared: &mut S) {
         if self.state.borrow().is_none() {
             return;
         }
         match &mut self.action {
             AsyncBehaviorType::Leaf(action) => {
-                action.reset();
+                action.reset(shared);
             }
             AsyncBehaviorType::Decorator(decorator, child) => {
-                child.reset();
+                child.reset(shared);
                 decorator.reset();
             }
             AsyncBehaviorType::Control(control, children) => {
                 children.iter_mut().for_each(|child| {
-                    child.reset();
+                    child.reset(shared);
                 });
                 control.reset();
             }

--- a/async_behaviortree/src/async_child.rs
+++ b/async_behaviortree/src/async_child.rs
@@ -1,0 +1,136 @@
+use std::rc::Rc;
+
+use behaviortree_common::{Behavior, Status};
+
+use crate::{
+    behavior_nodes::{AsyncInvertState, AsyncSelectState, AsyncSequenceState, AsyncWaitState},
+    AsyncAction, AsyncControl, AsyncDecorator, ToAsyncAction,
+};
+
+enum AsyncBehaviorType<S> {
+    Leaf(Box<dyn AsyncAction<S>>),
+    Decorator(Box<dyn AsyncDecorator<S>>, Box<AsyncChild<S>>),
+    Control(Box<dyn AsyncControl<S>>, Vec<AsyncChild<S>>),
+}
+
+pub type AsyncChildObserverChannel = tokio::sync::watch::Receiver<Option<Status>>;
+
+#[derive(Clone)]
+pub enum AsyncChildObserver {
+    NoChild(AsyncChildObserverChannel),
+    SingleChild(AsyncChildObserverChannel, Rc<AsyncChildObserver>),
+    MultipleChildren(AsyncChildObserverChannel, Rc<[AsyncChildObserver]>),
+}
+
+pub struct AsyncChild<S> {
+    action: AsyncBehaviorType<S>,
+    state: tokio::sync::watch::Sender<Option<Status>>,
+}
+
+impl<S> AsyncChild<S> {
+    pub fn from_behavior<A>(behavior: Behavior<A>) -> Self
+    where
+        A: ToAsyncAction<S>,
+        S: 'static,
+    {
+        let action = match behavior {
+            Behavior::Action(action) => AsyncBehaviorType::Leaf(action.to_async_action()),
+            Behavior::Wait(target) => {
+                AsyncBehaviorType::Leaf(Box::new(AsyncWaitState::new(target)))
+            }
+            Behavior::Invert(behavior) => {
+                let child = Self::from_behavior(*behavior);
+                let action = Box::new(AsyncInvertState::new());
+                AsyncBehaviorType::Decorator(action, Box::new(child))
+            }
+            Behavior::Sequence(behaviors) => {
+                let children = Self::from_behaviors(behaviors);
+                let action = Box::new(AsyncSequenceState::new());
+                AsyncBehaviorType::Control(action, children)
+            }
+            Behavior::Select(behaviors) => {
+                let children = Self::from_behaviors(behaviors);
+                let action = Box::new(AsyncSelectState::new());
+                AsyncBehaviorType::Control(action, children)
+            }
+        };
+        Self::from_action(action)
+    }
+
+    pub fn from_behaviors<A>(mut behaviors: Vec<Behavior<A>>) -> Vec<Self>
+    where
+        A: ToAsyncAction<S>,
+        S: 'static,
+    {
+        behaviors
+            .drain(..)
+            .map(|behavior| Self::from_behavior(behavior))
+            .collect()
+    }
+
+    pub async fn run(
+        &mut self,
+        delta: &mut tokio::sync::watch::Receiver<f64>,
+        shared: &mut S,
+    ) -> bool {
+        let _r = self.state.send(Some(Status::Running));
+        let success = match &mut self.action {
+            AsyncBehaviorType::Leaf(action) => action.run(delta, shared).await,
+            AsyncBehaviorType::Decorator(decorator, child) => {
+                decorator.run(child, delta, shared).await
+            }
+            AsyncBehaviorType::Control(control, children) => {
+                control.run(children, delta, shared).await
+            }
+        };
+        let status = if success {
+            Status::Success
+        } else {
+            Status::Failure
+        };
+        let _r = self.state.send(Some(status));
+        success
+    }
+
+    pub fn reset(&mut self) {
+        if self.state.borrow().is_none() {
+            return;
+        }
+        match &mut self.action {
+            AsyncBehaviorType::Leaf(action) => {
+                action.reset();
+            }
+            AsyncBehaviorType::Decorator(decorator, child) => {
+                child.reset();
+                decorator.reset();
+            }
+            AsyncBehaviorType::Control(control, children) => {
+                children.iter_mut().for_each(|child| {
+                    child.reset();
+                });
+                control.reset();
+            }
+        }
+        let _r = self.state.send(None);
+    }
+
+    pub fn observer(&self) -> AsyncChildObserver {
+        match &self.action {
+            AsyncBehaviorType::Leaf(_) => AsyncChildObserver::NoChild(self.state.subscribe()),
+            AsyncBehaviorType::Decorator(_, child) => {
+                AsyncChildObserver::SingleChild(self.state.subscribe(), Rc::new(child.observer()))
+            }
+            AsyncBehaviorType::Control(_, children) => {
+                let children = children.iter().map(|child| child.observer()).collect();
+                AsyncChildObserver::MultipleChildren(self.state.subscribe(), children)
+            }
+        }
+    }
+
+    fn from_action(action: AsyncBehaviorType<S>) -> Self {
+        Self {
+            action,
+            state: tokio::sync::watch::channel(None).0,
+        }
+    }
+}

--- a/async_behaviortree/src/behavior_nodes/wait_node.rs
+++ b/async_behaviortree/src/behavior_nodes/wait_node.rs
@@ -39,7 +39,7 @@ impl<S> AsyncAction<S> for AsyncWaitState {
         true
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self, _shared: &mut S) {
         self.elapsed = 0.0;
     }
 }
@@ -83,7 +83,7 @@ mod tests {
         executor
             .spawn_local("WaitFuture", async move {
                 wait.run(&mut delta, &mut shared).await;
-                wait.reset();
+                wait.reset(&mut shared);
                 wait.run(&mut delta, &mut shared).await;
             })
             .detach();

--- a/async_behaviortree/src/lib.rs
+++ b/async_behaviortree/src/lib.rs
@@ -3,6 +3,9 @@ pub use behaviortree_common::*;
 mod async_behavior_interface;
 pub use async_behavior_interface::*;
 
+mod async_child;
+pub use async_child::*;
+
 mod async_behaviortree;
 pub use async_behaviortree::*;
 

--- a/async_behaviortree/src/lib.rs
+++ b/async_behaviortree/src/lib.rs
@@ -1,5 +1,3 @@
-pub use behaviortree_common::*;
-
 mod async_behavior_interface;
 pub use async_behavior_interface::*;
 


### PR DESCRIPTION
- Use tokio::sync::watch channel for observing individual child state
- Split `AsyncAction` into `AsyncAction`, `AsyncDecorator` and `AsyncControl` node types
- AsyncChild now consumes `AsyncBehaviorType` which is an enum comprising of the above mentioned traits
- Added AsyncChildObserver which provides a watch channel for each child