### PR TITLE
AsyncBehaviorTree updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ serde = { version = "1.0", features = ["rc", "derive"] }
 
 # Async
 tokio = { version = "1", default-features = false, features = [
+    "rt",
     "macros",
     "sync",
 ] }

--- a/async_behaviortree/Cargo.toml
+++ b/async_behaviortree/Cargo.toml
@@ -10,7 +10,6 @@ tokio = { workspace = true }
 behaviortree_common = { path = "../behaviortree_common" }
 
 async-trait = "0.1.80"
-async-std = "1.12.0"
 
 [dev-dependencies]
 ticked_async_executor = { git = "https://github.com/coder137/ticked-async-executor", rev = "45c76da3730e0f77f08c9f6af86f00832c89fe1e" }

--- a/async_behaviortree/Cargo.toml
+++ b/async_behaviortree/Cargo.toml
@@ -5,16 +5,12 @@ edition = "2021"
 
 [dependencies]
 serde = { workspace = true }
+tokio = { workspace = true }
 
 behaviortree_common = { path = "../behaviortree_common" }
 
 async-trait = "0.1.80"
 async-std = "1.12.0"
-
-tokio = { version = "1.38.0", default-features = false, features = [
-    "macros",
-    "sync",
-] }
 
 [dev-dependencies]
 ticked_async_executor = { git = "https://github.com/coder137/ticked-async-executor", rev = "45c76da3730e0f77f08c9f6af86f00832c89fe1e" }

--- a/async_behaviortree/Cargo.toml
+++ b/async_behaviortree/Cargo.toml
@@ -12,6 +12,6 @@ behaviortree_common = { path = "../behaviortree_common" }
 async-trait = "0.1.80"
 
 [dev-dependencies]
-ticked_async_executor = { git = "https://github.com/coder137/ticked-async-executor", rev = "45c76da3730e0f77f08c9f6af86f00832c89fe1e" }
+ticked_async_executor = { git = "https://github.com/coder137/ticked-async-executor", rev = "a792d18fa778613138b91b493e95768d448613a1" }
 
 tokio-stream = { version = "0.1.15", features = ["full"] }

--- a/async_behaviortree/src/async_behavior_interface.rs
+++ b/async_behaviortree/src/async_behavior_interface.rs
@@ -17,6 +17,9 @@ pub trait AsyncAction<S> {
     ///
     /// Decorator and Control nodes need to also reset their ticked children
     fn reset(&mut self, shared: &mut S);
+
+    /// Identify your action
+    fn name(&self) -> &'static str;
 }
 
 pub trait ToAsyncAction<S> {
@@ -57,14 +60,16 @@ pub mod test_async_behavior_interface {
     pub struct TestShared;
 
     struct GenericTestAction {
+        name: &'static str,
         status: bool,
         times: usize,
         elapsed: usize,
     }
 
     impl GenericTestAction {
-        fn new(status: bool, times: usize) -> Self {
+        fn new(name: String, status: bool, times: usize) -> Self {
             Self {
+                name: Box::new(name).leak(),
                 status,
                 times,
                 elapsed: 0,
@@ -95,6 +100,10 @@ pub mod test_async_behavior_interface {
         fn reset(&mut self, _shared: &mut S) {
             self.elapsed = 0;
         }
+
+        fn name(&self) -> &'static str {
+            self.name
+        }
     }
 
     #[derive(Clone, Copy)]
@@ -108,14 +117,18 @@ pub mod test_async_behavior_interface {
     impl<S> ToAsyncAction<S> for TestAction {
         fn to_async_action(self) -> Box<dyn AsyncAction<S>> {
             match self {
-                TestAction::Success => Box::new(GenericTestAction::new(true, 1)),
-                TestAction::Failure => Box::new(GenericTestAction::new(false, 1)),
-                TestAction::SuccessAfter { times } => {
-                    Box::new(GenericTestAction::new(true, times + 1))
-                }
-                TestAction::FailureAfter { times } => {
-                    Box::new(GenericTestAction::new(false, times + 1))
-                }
+                TestAction::Success => Box::new(GenericTestAction::new("Success".into(), true, 1)),
+                TestAction::Failure => Box::new(GenericTestAction::new("Failure".into(), false, 1)),
+                TestAction::SuccessAfter { times } => Box::new(GenericTestAction::new(
+                    format!("SuccessAfter{}", times),
+                    true,
+                    times + 1,
+                )),
+                TestAction::FailureAfter { times } => Box::new(GenericTestAction::new(
+                    format!("FailureAfter{}", times),
+                    false,
+                    times + 1,
+                )),
             }
         }
     }

--- a/async_behaviortree/src/async_behavior_interface.rs
+++ b/async_behaviortree/src/async_behavior_interface.rs
@@ -63,7 +63,7 @@ pub mod test_async_behavior_interface {
                 let _dt = *delta.borrow_and_update();
                 self.elapsed += 1;
                 if self.elapsed < self.times {
-                    async_std::task::yield_now().await;
+                    tokio::task::yield_now().await;
                 } else {
                     break;
                 }

--- a/async_behaviortree/src/async_behavior_interface.rs
+++ b/async_behaviortree/src/async_behavior_interface.rs
@@ -1,5 +1,3 @@
-use crate::AsyncChild;
-
 #[async_trait::async_trait(?Send)]
 pub trait AsyncAction<S> {
     /// Asynchronously runs the action till completion
@@ -24,30 +22,6 @@ pub trait AsyncAction<S> {
 
 pub trait ToAsyncAction<S> {
     fn to_async_action(self) -> Box<dyn AsyncAction<S>>;
-}
-
-#[async_trait::async_trait(?Send)]
-pub trait AsyncDecorator<S> {
-    async fn run(
-        &mut self,
-        child: &mut AsyncChild<S>,
-        delta: &mut tokio::sync::watch::Receiver<f64>,
-        shared: &mut S,
-    ) -> bool;
-
-    fn reset(&mut self);
-}
-
-#[async_trait::async_trait(?Send)]
-pub trait AsyncControl<S> {
-    async fn run(
-        &mut self,
-        children: &mut [AsyncChild<S>],
-        delta: &mut tokio::sync::watch::Receiver<f64>,
-        shared: &mut S,
-    ) -> bool;
-
-    fn reset(&mut self);
 }
 
 #[cfg(test)]

--- a/async_behaviortree/src/async_behaviortree.rs
+++ b/async_behaviortree/src/async_behaviortree.rs
@@ -74,7 +74,7 @@ impl AsyncBehaviorTree {
                 match state {
                     State::ChildCompleted => match behavior_policy {
                         AsyncBehaviorTreePolicy::ReloadOnCompletion => {
-                            async_std::task::yield_now().await;
+                            tokio::task::yield_now().await;
                             child.reset(&mut shared);
                         }
                         AsyncBehaviorTreePolicy::RetainOnCompletion => {
@@ -83,7 +83,7 @@ impl AsyncBehaviorTree {
                     },
                     State::ResetNotification => {
                         reset_rx.mark_unchanged();
-                        async_std::task::yield_now().await;
+                        tokio::task::yield_now().await;
                         child.reset(&mut shared);
                         match behavior_policy {
                             AsyncBehaviorTreePolicy::ReloadOnCompletion => {}

--- a/async_behaviortree/src/async_behaviortree.rs
+++ b/async_behaviortree/src/async_behaviortree.rs
@@ -198,17 +198,17 @@ mod tests {
                 }
             })
             .detach();
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
 
         executor
             .spawn_local("AsyncBehaviorTreeFuture", behaviortree_future)
             .detach();
 
-        executor.tick(DELTA);
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
         let _r = shut_tx.try_send(());
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -233,11 +233,11 @@ mod tests {
             .spawn_local("AsyncBehaviorTreeFuture", behaviortree_future)
             .detach();
 
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         controller.reset();
 
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -265,13 +265,13 @@ mod tests {
 
         let observer = controller.observer();
         for _ in 0..10 {
-            executor.tick(DELTA);
+            executor.tick(DELTA, None);
             println!("Observer: {observer:?}");
         }
         controller.shutdown();
 
         while executor.num_tasks() != 0 {
-            executor.tick(DELTA);
+            executor.tick(DELTA, None);
         }
         assert_eq!(executor.num_tasks(), 0);
     }

--- a/async_behaviortree/src/behavior_nodes/invert_node.rs
+++ b/async_behaviortree/src/behavior_nodes/invert_node.rs
@@ -1,44 +1,47 @@
 use async_trait::async_trait;
 
-use crate::{AsyncChild, AsyncDecorator};
+use crate::{AsyncAction, AsyncChild};
 
-pub struct AsyncInvertState {
+pub struct AsyncInvertState<S> {
+    child: AsyncChild<S>,
     completed: bool,
 }
 
-impl AsyncInvertState {
-    pub fn new() -> Self {
-        Self { completed: false }
+impl<S> AsyncInvertState<S> {
+    pub fn new(child: AsyncChild<S>) -> Self {
+        Self {
+            child,
+            completed: false,
+        }
     }
 }
 
 #[async_trait(?Send)]
-impl<S> AsyncDecorator<S> for AsyncInvertState {
-    async fn run(
-        &mut self,
-        child: &mut AsyncChild<S>,
-        delta: &mut tokio::sync::watch::Receiver<f64>,
-        shared: &mut S,
-    ) -> bool {
+impl<S> AsyncAction<S> for AsyncInvertState<S> {
+    async fn run(&mut self, delta: &mut tokio::sync::watch::Receiver<f64>, shared: &mut S) -> bool {
         match self.completed {
             true => {
                 unreachable!()
             }
             false => {}
         }
-        let status = !child.run(delta, shared).await;
+        let status = !self.child.run(delta, shared).await;
         self.completed = true;
         status
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self, shared: &mut S) {
+        self.child.reset(shared);
         self.completed = false;
+    }
+
+    fn name(&self) -> &'static str {
+        "Invert"
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::{
         test_async_behavior_interface::{TestAction, TestShared, DELTA},
         AsyncChild,
@@ -48,10 +51,8 @@ mod tests {
 
     #[test]
     fn test_invert_success() {
-        let behavior = Behavior::Action(TestAction::Success);
-        let mut child = AsyncChild::from_behavior(behavior);
-
-        let mut invert = AsyncInvertState::new();
+        let behavior = Behavior::Invert(Behavior::Action(TestAction::Success).into());
+        let mut invert = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -60,7 +61,7 @@ mod tests {
 
         executor
             .spawn_local("InvertFuture", async move {
-                let status = invert.run(&mut child, &mut delta, &mut shared).await;
+                let status = invert.run(&mut delta, &mut shared).await;
                 assert!(!status);
             })
             .detach();
@@ -72,10 +73,8 @@ mod tests {
 
     #[test]
     fn test_invert_failure() {
-        let behavior = Behavior::Action(TestAction::Failure);
-        let mut child = AsyncChild::from_behavior(behavior);
-
-        let mut invert = AsyncInvertState::new();
+        let behavior = Behavior::Invert(Behavior::Action(TestAction::Failure).into());
+        let mut invert = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -84,7 +83,7 @@ mod tests {
 
         executor
             .spawn_local("InvertFuture", async move {
-                let status = invert.run(&mut child, &mut delta, &mut shared).await;
+                let status = invert.run(&mut delta, &mut shared).await;
                 assert!(status);
             })
             .detach();
@@ -96,10 +95,9 @@ mod tests {
 
     #[test]
     fn test_invert_running_with_reset() {
-        let behavior = Behavior::Action(TestAction::SuccessAfter { times: 2 });
-        let mut child = AsyncChild::from_behavior(behavior);
-
-        let mut invert: Box<dyn AsyncDecorator<TestShared>> = Box::new(AsyncInvertState::new());
+        let behavior =
+            Behavior::Invert(Behavior::Action(TestAction::SuccessAfter { times: 2 }).into());
+        let mut invert = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -108,10 +106,10 @@ mod tests {
 
         executor
             .spawn_local("InvertFuture", async move {
-                let status = invert.run(&mut child, &mut delta, &mut shared).await;
+                let status = invert.run(&mut delta, &mut shared).await;
                 assert!(!status);
-                invert.reset();
-                let status = invert.run(&mut child, &mut delta, &mut shared).await;
+                invert.reset(&mut shared);
+                let status = invert.run(&mut delta, &mut shared).await;
                 assert!(!status);
             })
             .detach();

--- a/async_behaviortree/src/behavior_nodes/invert_node.rs
+++ b/async_behaviortree/src/behavior_nodes/invert_node.rs
@@ -67,7 +67,7 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -89,7 +89,7 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -115,15 +115,15 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
 
         // Reset here
 
-        executor.tick(DELTA);
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 }

--- a/async_behaviortree/src/behavior_nodes/select_node.rs
+++ b/async_behaviortree/src/behavior_nodes/select_node.rs
@@ -1,32 +1,31 @@
 use async_trait::async_trait;
 
-use crate::{AsyncChild, AsyncControl};
+use crate::{AsyncAction, AsyncChild};
 
-pub struct AsyncSelectState {
+pub struct AsyncSelectState<S> {
+    children: Vec<AsyncChild<S>>,
     completed: bool,
 }
 
-impl AsyncSelectState {
-    pub fn new() -> Self {
-        Self { completed: false }
+impl<S> AsyncSelectState<S> {
+    pub fn new(children: Vec<AsyncChild<S>>) -> Self {
+        Self {
+            children,
+            completed: false,
+        }
     }
 }
 
 #[async_trait(?Send)]
-impl<S> AsyncControl<S> for AsyncSelectState {
-    async fn run(
-        &mut self,
-        children: &mut [AsyncChild<S>],
-        delta: &mut tokio::sync::watch::Receiver<f64>,
-        shared: &mut S,
-    ) -> bool {
+impl<S> AsyncAction<S> for AsyncSelectState<S> {
+    async fn run(&mut self, delta: &mut tokio::sync::watch::Receiver<f64>, shared: &mut S) -> bool {
         match self.completed {
             true => unreachable!(),
             false => {}
         }
         let mut status = false;
-        let last = children.len() - 1;
-        for (index, child) in children.iter_mut().enumerate() {
+        let last = self.children.len() - 1;
+        for (index, child) in self.children.iter_mut().enumerate() {
             let child_status = child.run(delta, shared).await;
             if child_status {
                 status = true;
@@ -36,15 +35,22 @@ impl<S> AsyncControl<S> for AsyncSelectState {
             // This means that if they are more children after the current child,
             // we must yield back to the executor
             if index != last {
-                async_std::task::yield_now().await;
+                tokio::task::yield_now().await;
             }
         }
         self.completed = true;
         status
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self, shared: &mut S) {
+        self.children.iter_mut().for_each(|child| {
+            child.reset(shared);
+        });
         self.completed = false;
+    }
+
+    fn name(&self) -> &'static str {
+        "Select"
     }
 }
 
@@ -59,8 +65,8 @@ mod tests {
 
     #[test]
     fn test_select_success() {
-        let mut children = AsyncChild::from_behaviors(vec![Behavior::Action(TestAction::Success)]);
-        let mut select = AsyncSelectState::new();
+        let behavior = Behavior::Select(vec![Behavior::Action(TestAction::Success)]);
+        let mut select = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -69,7 +75,7 @@ mod tests {
 
         executor
             .spawn_local("SelectFuture", async move {
-                let status = select.run(&mut children, &mut delta, &mut shared).await;
+                let status = select.run(&mut delta, &mut shared).await;
                 assert!(status);
             })
             .detach();
@@ -81,8 +87,8 @@ mod tests {
 
     #[test]
     fn test_select_failure() {
-        let mut children = AsyncChild::from_behaviors(vec![Behavior::Action(TestAction::Failure)]);
-        let mut select = AsyncSelectState::new();
+        let behavior = Behavior::Select(vec![Behavior::Action(TestAction::Failure)]);
+        let mut select = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -91,7 +97,7 @@ mod tests {
 
         executor
             .spawn_local("SelectFuture", async move {
-                let status = select.run(&mut children, &mut delta, &mut shared).await;
+                let status = select.run(&mut delta, &mut shared).await;
                 assert!(!status);
             })
             .detach();
@@ -103,11 +109,10 @@ mod tests {
 
     #[test]
     fn test_select_running() {
-        let mut children =
-            AsyncChild::from_behaviors(vec![Behavior::Action(TestAction::SuccessAfter {
-                times: 1,
-            })]);
-        let mut select = AsyncSelectState::new();
+        let behavior = Behavior::Select(vec![Behavior::Action(TestAction::SuccessAfter {
+            times: 1,
+        })]);
+        let mut select = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -116,7 +121,7 @@ mod tests {
 
         executor
             .spawn_local("SelectFuture", async move {
-                let status = select.run(&mut children, &mut delta, &mut shared).await;
+                let status = select.run(&mut delta, &mut shared).await;
                 assert!(status);
             })
             .detach();
@@ -129,11 +134,11 @@ mod tests {
 
     #[test]
     fn test_select_multiple_children() {
-        let mut children = AsyncChild::from_behaviors(vec![
+        let behavior = Behavior::Select(vec![
             Behavior::Action(TestAction::Failure),
             Behavior::Action(TestAction::Failure),
         ]);
-        let mut select = AsyncSelectState::new();
+        let mut select = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -142,7 +147,7 @@ mod tests {
 
         executor
             .spawn_local("SelectFuture", async move {
-                let status = select.run(&mut children, &mut delta, &mut shared).await;
+                let status = select.run(&mut delta, &mut shared).await;
                 assert!(!status);
             })
             .detach();
@@ -156,12 +161,12 @@ mod tests {
 
     #[test]
     fn test_select_multiple_children_early_failure() {
-        let mut children = AsyncChild::from_behaviors(vec![
+        let behavior = Behavior::Select(vec![
             Behavior::Action(TestAction::Failure),
             Behavior::Action(TestAction::Success),
             Behavior::Action(TestAction::Success),
         ]);
-        let mut select: Box<dyn AsyncControl<TestShared>> = Box::new(AsyncSelectState::new());
+        let mut select = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -170,10 +175,10 @@ mod tests {
 
         executor
             .spawn_local("SelectFuture", async move {
-                let status = select.run(&mut children, &mut delta, &mut shared).await;
+                let status = select.run(&mut delta, &mut shared).await;
                 assert!(status);
-                select.reset();
-                let status = select.run(&mut children, &mut delta, &mut shared).await;
+                select.reset(&mut shared);
+                let status = select.run(&mut delta, &mut shared).await;
                 assert!(status);
             })
             .detach();

--- a/async_behaviortree/src/behavior_nodes/select_node.rs
+++ b/async_behaviortree/src/behavior_nodes/select_node.rs
@@ -81,7 +81,7 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -103,7 +103,7 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -127,8 +127,8 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -153,9 +153,9 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -184,12 +184,12 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
         // reset
 
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 }

--- a/async_behaviortree/src/behavior_nodes/sequence_node.rs
+++ b/async_behaviortree/src/behavior_nodes/sequence_node.rs
@@ -83,7 +83,7 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -105,7 +105,7 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -129,8 +129,8 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -155,9 +155,9 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -186,12 +186,12 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
         // reset
 
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 }

--- a/async_behaviortree/src/behavior_nodes/sequence_node.rs
+++ b/async_behaviortree/src/behavior_nodes/sequence_node.rs
@@ -1,25 +1,24 @@
 use async_trait::async_trait;
 
-use crate::{AsyncChild, AsyncControl};
+use crate::{AsyncAction, AsyncChild};
 
-pub struct AsyncSequenceState {
+pub struct AsyncSequenceState<S> {
+    children: Vec<AsyncChild<S>>,
     completed: bool,
 }
 
-impl AsyncSequenceState {
-    pub fn new() -> Self {
-        Self { completed: false }
+impl<S> AsyncSequenceState<S> {
+    pub fn new(children: Vec<AsyncChild<S>>) -> Self {
+        Self {
+            children,
+            completed: false,
+        }
     }
 }
 
 #[async_trait(?Send)]
-impl<S> AsyncControl<S> for AsyncSequenceState {
-    async fn run(
-        &mut self,
-        children: &mut [AsyncChild<S>],
-        delta: &mut tokio::sync::watch::Receiver<f64>,
-        shared: &mut S,
-    ) -> bool {
+impl<S> AsyncAction<S> for AsyncSequenceState<S> {
+    async fn run(&mut self, delta: &mut tokio::sync::watch::Receiver<f64>, shared: &mut S) -> bool {
         match self.completed {
             true => {
                 unreachable!()
@@ -27,8 +26,8 @@ impl<S> AsyncControl<S> for AsyncSequenceState {
             false => {}
         }
         let mut status = true;
-        let last = children.len() - 1;
-        for (index, child) in children.iter_mut().enumerate() {
+        let last = self.children.len() - 1;
+        for (index, child) in self.children.iter_mut().enumerate() {
             let child_status = child.run(delta, shared).await;
             if !child_status {
                 status = false;
@@ -38,15 +37,22 @@ impl<S> AsyncControl<S> for AsyncSequenceState {
             // This means that if they are more children after the current child,
             // we must yield back to the executor
             if index != last {
-                async_std::task::yield_now().await;
+                tokio::task::yield_now().await;
             }
         }
         self.completed = true;
         status
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self, shared: &mut S) {
+        self.children
+            .iter_mut()
+            .for_each(|child| child.reset(shared));
         self.completed = false;
+    }
+
+    fn name(&self) -> &'static str {
+        "Sequence"
     }
 }
 
@@ -61,8 +67,8 @@ mod tests {
 
     #[test]
     fn test_sequence_success() {
-        let mut children = AsyncChild::from_behaviors(vec![Behavior::Action(TestAction::Success)]);
-        let mut sequence = AsyncSequenceState::new();
+        let behavior = Behavior::Sequence(vec![Behavior::Action(TestAction::Success)]);
+        let mut sequence = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -71,7 +77,7 @@ mod tests {
 
         executor
             .spawn_local("SequenceFuture", async move {
-                let status = sequence.run(&mut children, &mut delta, &mut shared).await;
+                let status = sequence.run(&mut delta, &mut shared).await;
                 assert!(status);
             })
             .detach();
@@ -83,8 +89,8 @@ mod tests {
 
     #[test]
     fn test_sequence_failure() {
-        let mut children = AsyncChild::from_behaviors(vec![Behavior::Action(TestAction::Failure)]);
-        let mut sequence = AsyncSequenceState::new();
+        let behavior = Behavior::Sequence(vec![Behavior::Action(TestAction::Failure)]);
+        let mut sequence = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -93,7 +99,7 @@ mod tests {
 
         executor
             .spawn_local("SequenceFuture", async move {
-                let status = sequence.run(&mut children, &mut delta, &mut shared).await;
+                let status = sequence.run(&mut delta, &mut shared).await;
                 assert!(!status);
             })
             .detach();
@@ -105,11 +111,10 @@ mod tests {
 
     #[test]
     fn test_sequence_running() {
-        let mut children =
-            AsyncChild::from_behaviors(vec![Behavior::Action(TestAction::SuccessAfter {
-                times: 1,
-            })]);
-        let mut sequence = AsyncSequenceState::new();
+        let behavior = Behavior::Sequence(vec![Behavior::Action(TestAction::SuccessAfter {
+            times: 1,
+        })]);
+        let mut sequence = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -118,7 +123,7 @@ mod tests {
 
         executor
             .spawn_local("SequenceFuture", async move {
-                let status = sequence.run(&mut children, &mut delta, &mut shared).await;
+                let status = sequence.run(&mut delta, &mut shared).await;
                 assert!(status);
             })
             .detach();
@@ -131,11 +136,11 @@ mod tests {
 
     #[test]
     fn test_sequence_multiple_children() {
-        let mut children = AsyncChild::from_behaviors(vec![
+        let behavior = Behavior::Sequence(vec![
             Behavior::Action(TestAction::Success),
             Behavior::Action(TestAction::Success),
         ]);
-        let mut sequence = AsyncSequenceState::new();
+        let mut sequence = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -144,7 +149,7 @@ mod tests {
 
         executor
             .spawn_local("SequenceFuture", async move {
-                let status = sequence.run(&mut children, &mut delta, &mut shared).await;
+                let status = sequence.run(&mut delta, &mut shared).await;
                 assert!(status);
             })
             .detach();
@@ -158,12 +163,12 @@ mod tests {
 
     #[test]
     fn test_sequence_multiple_children_early_failure() {
-        let mut children = AsyncChild::from_behaviors(vec![
+        let behavior = Behavior::Sequence(vec![
             Behavior::Action(TestAction::Success),
             Behavior::Action(TestAction::Failure),
             Behavior::Action(TestAction::Success),
         ]);
-        let mut sequence: Box<dyn AsyncControl<TestShared>> = Box::new(AsyncSequenceState::new());
+        let mut sequence = AsyncChild::from_behavior(behavior);
 
         let executor = TickedAsyncExecutor::default();
 
@@ -172,10 +177,10 @@ mod tests {
 
         executor
             .spawn_local("SequenceFuture", async move {
-                let status = sequence.run(&mut children, &mut delta, &mut shared).await;
+                let status = sequence.run(&mut delta, &mut shared).await;
                 assert!(!status);
-                sequence.reset();
-                let status = sequence.run(&mut children, &mut delta, &mut shared).await;
+                sequence.reset(&mut shared);
+                let status = sequence.run(&mut delta, &mut shared).await;
                 assert!(!status);
             })
             .detach();

--- a/async_behaviortree/src/behavior_nodes/wait_node.rs
+++ b/async_behaviortree/src/behavior_nodes/wait_node.rs
@@ -42,6 +42,10 @@ impl<S> AsyncAction<S> for AsyncWaitState {
     fn reset(&mut self, _shared: &mut S) {
         self.elapsed = 0.0;
     }
+
+    fn name(&self) -> &'static str {
+        "Wait"
+    }
 }
 
 #[cfg(test)]

--- a/async_behaviortree/src/behavior_nodes/wait_node.rs
+++ b/async_behaviortree/src/behavior_nodes/wait_node.rs
@@ -34,7 +34,7 @@ impl<S> AsyncAction<S> for AsyncWaitState {
             if self.elapsed >= self.target {
                 break;
             }
-            async_std::task::yield_now().await;
+            tokio::task::yield_now().await;
         }
         true
     }

--- a/async_behaviortree/src/behavior_nodes/wait_node.rs
+++ b/async_behaviortree/src/behavior_nodes/wait_node.rs
@@ -71,7 +71,7 @@ mod tests {
             .detach();
 
         assert_eq!(executor.num_tasks(), 1);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -92,15 +92,15 @@ mod tests {
             })
             .detach();
 
-        executor.tick(DELTA);
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
 
         // reset
 
-        executor.tick(DELTA);
-        executor.tick(DELTA);
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
+        executor.tick(DELTA, None);
         assert_eq!(executor.num_tasks(), 0);
     }
 
@@ -119,7 +119,7 @@ mod tests {
             })
             .detach();
 
-        executor.tick(DELTA);
+        executor.tick(DELTA, None);
         drop(executor);
     }
 }

--- a/behaviortree/src/behavior_interface.rs
+++ b/behaviortree/src/behavior_interface.rs
@@ -133,14 +133,16 @@ pub mod test_behavior_interface {
     pub struct TestShared;
 
     struct GenericTestAction {
+        name: &'static str,
         status: bool,
         times: usize,
         elapsed: usize,
     }
 
     impl GenericTestAction {
-        fn new(status: bool, times: usize) -> Self {
+        fn new(name: String, status: bool, times: usize) -> Self {
             Self {
+                name: Box::new(name).leak(),
                 status,
                 times,
                 elapsed: 0,
@@ -168,7 +170,7 @@ pub mod test_behavior_interface {
         }
 
         fn name(&self) -> &'static str {
-            "GenericTestAction"
+            self.name
         }
     }
 
@@ -183,15 +185,23 @@ pub mod test_behavior_interface {
     impl ToAction<TestShared> for TestAction {
         fn to_action(self) -> Box<dyn Action<TestShared>> {
             match self {
-                TestAction::Success => Box::new(GenericTestAction::new(true, 1)),
-                TestAction::Failure => Box::new(GenericTestAction::new(false, 1)),
+                TestAction::Success => Box::new(GenericTestAction::new("Success".into(), true, 1)),
+                TestAction::Failure => Box::new(GenericTestAction::new("Failure".into(), false, 1)),
                 TestAction::SuccessAfter { times } => {
                     assert!(times >= 1);
-                    Box::new(GenericTestAction::new(true, times + 1))
+                    Box::new(GenericTestAction::new(
+                        format!("SuccessAfter{}", times),
+                        true,
+                        times + 1,
+                    ))
                 }
                 TestAction::FailureAfter { times } => {
                     assert!(times >= 1);
-                    Box::new(GenericTestAction::new(false, times + 1))
+                    Box::new(GenericTestAction::new(
+                        format!("FailureAfter{}", times),
+                        false,
+                        times + 1,
+                    ))
                 }
             }
         }

--- a/behaviortree/src/lib.rs
+++ b/behaviortree/src/lib.rs
@@ -1,8 +1,5 @@
 pub use behaviortree_common::*;
 
-mod state;
-pub use state::*;
-
 mod blackboard;
 pub use blackboard::*;
 

--- a/behaviortree_common/Cargo.toml
+++ b/behaviortree_common/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 serde = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]

--- a/behaviortree_common/src/lib.rs
+++ b/behaviortree_common/src/lib.rs
@@ -3,3 +3,6 @@ pub use status::*;
 
 mod behavior;
 pub use behavior::*;
+
+mod state;
+pub use state::*;

--- a/behaviortree_common/src/state.rs
+++ b/behaviortree_common/src/state.rs
@@ -1,4 +1,4 @@
-use behaviortree_common::Status;
+use crate::Status;
 
 #[derive(Clone)]
 pub enum State {


### PR DESCRIPTION
- `behaviortree_common::State` usage in both `BehaviorTree` and `AsyncBehaviorTree`
- Removed `AsyncControl` and `AsyncDecorator` traits. All nodes now implement `AsyncAction`
- Added `name()` API to `AsyncAction`