### PR TITLE
Immediate action: BehaviorTree and AsyncBehaviorTree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["behaviortree_common", "behaviortree", "async_behaviortree"]
+members = ["behaviortree", "async_behaviortree"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ class BehaviorTree {
     reset(&mut self)
 }
 
+class AsyncBehaviorTree {
+    <<struct>>
+    AsyncChild~S~ child
+}
+
 Behavior --> ImmediateAction
 Behavior --> SyncAction
 Behavior --> AsyncAction
@@ -87,20 +92,19 @@ ActionType --> Child
 Child --> BehaviorTree
 
 AsyncActionType --> AsyncChild
+AsyncChild --> AsyncBehaviorTree
 ```
 
 # Roadmap
 
-- [x] Action trait
-  - [ ] Rename from `Action` to `SyncAction`
-- [x] AsyncAction trait
 - [x] ImmediateAction trait
-- [ ] Unification
-  - [ ] Remove workspace and keep only 1 crate
-  - [ ] Unify `SyncAction` with `ImmediateAction`
-  - [ ] Unify `AsyncAction` with `ImmediateAction`
+- [x] SyncAction trait
+- [x] AsyncAction trait
 - [ ] Behavior Nodes
   - [x] Wait
   - [x] Invert
   - [x] Sequence
   - [x] Select
+- [ ] Tracing
+  - [x] BehaviorTree
+  - [ ] AsyncBehaviorTree

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ class SyncAction~S~ {
 
 class AsyncAction~S~ {
     <<trait>>
-    async fn run(&mut self, delta: &mut watch::Receiver<f64>, shared: &mut S) bool
+    async fn run(&mut self, delta: &mut watch::Receiver~f64~, shared: &mut S) bool
     fn reset(&mut self, shared: &mut S)
     fn name(&self) &'static str
 }
@@ -36,6 +36,11 @@ class ActionType~S~ {
     Immediate
     Sync
     Async
+
+    fn tick(&mut self, delta: f64, shared: &mut S) Status
+    async fn run(&mut self, delta: &mut watch::Receiver~f64~, shared: &mut S) bool
+    fn reset(&mut self, shared: &mut S)
+    fn name(&self) &'static str
 }
 
 class Child~S~ {

--- a/README.md
+++ b/README.md
@@ -43,3 +43,12 @@ Action <-- ToAction
 ToAction --> Child
 Child --> BehaviorTree
 ```
+
+# Roadmap
+
+- [x] SyncAction
+  - [ ] Rename from `Action` to `SyncAction`
+- [x] AsyncAction
+- [x] ImmediateAction
+- [ ] Unify `SyncAction`, `AsyncAction` and `ImmediateAction`
+- [ ] Behavior Nodes

--- a/README.md
+++ b/README.md
@@ -35,9 +35,17 @@ class ActionType~S~ {
     <<enum>>
     Immediate
     Sync
-    Async
 
     fn tick(&mut self, delta: f64, shared: &mut S) Status
+    fn reset(&mut self, shared: &mut S)
+    fn name(&self) &'static str
+}
+
+class AsyncActionType~S~ {
+    <<enum>>
+    Immediate
+    Async
+
     async fn run(&mut self, delta: &mut watch::Receiver~f64~, shared: &mut S) bool
     fn reset(&mut self, shared: &mut S)
     fn name(&self) &'static str
@@ -46,9 +54,15 @@ class ActionType~S~ {
 class Child~S~ {
     <<struct>>
     ActionType~S~ action_type
-    tokio::sync::watch::Sender~Option~Status~~ status
 
     fn from_behavior~A~(Behavior~A~ behavior) Self where A: Into~ActionType~S~~
+}
+
+class AsyncChild~S~ {
+    <<struct>>
+    AsyncActionType~S~ action_type
+
+    fn from_behavior~A~(Behavior~A~ behavior) Self where A: Into~AsyncActionType~S~~
 }
 
 class BehaviorTree {
@@ -63,11 +77,16 @@ class BehaviorTree {
 Behavior --> ImmediateAction
 Behavior --> SyncAction
 Behavior --> AsyncAction
-ImmediateAction --> ActionType
+
 SyncAction --> ActionType
-AsyncAction --> ActionType
+ImmediateAction --> ActionType
+ImmediateAction --> AsyncActionType
+AsyncAction --> AsyncActionType
+
 ActionType --> Child
 Child --> BehaviorTree
+
+AsyncActionType --> AsyncChild
 ```
 
 # Roadmap
@@ -76,7 +95,10 @@ Child --> BehaviorTree
   - [ ] Rename from `Action` to `SyncAction`
 - [x] AsyncAction trait
 - [x] ImmediateAction trait
-- [ ] Unify `ImmediateAction`, `SyncAction` and `AsyncAction`
+- [ ] Unification
+  - [ ] Remove workspace and keep only 1 crate
+  - [ ] Unify `SyncAction` with `ImmediateAction`
+  - [ ] Unify `AsyncAction` with `ImmediateAction`
 - [ ] Behavior Nodes
   - [x] Wait
   - [x] Invert

--- a/async_behaviortree/Cargo.toml
+++ b/async_behaviortree/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async_behaviortree"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 serde = { workspace = true }

--- a/async_behaviortree/Cargo.toml
+++ b/async_behaviortree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async_behaviortree"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]

--- a/async_behaviortree/src/action_type.rs
+++ b/async_behaviortree/src/action_type.rs
@@ -12,7 +12,10 @@ impl<S> ActionType<S> {
         shared: &mut S,
     ) -> bool {
         match self {
-            ActionType::Immediate(immediate_action) => immediate_action.run(shared),
+            ActionType::Immediate(immediate_action) => {
+                let dt = *delta.borrow_and_update();
+                immediate_action.run(dt, shared)
+            }
             ActionType::Async(async_action) => async_action.run(delta, shared).await,
         }
     }

--- a/async_behaviortree/src/action_type.rs
+++ b/async_behaviortree/src/action_type.rs
@@ -1,0 +1,33 @@
+use crate::{AsyncAction, ImmediateAction};
+
+pub enum ActionType<S> {
+    Immediate(Box<dyn ImmediateAction<S>>),
+    Async(Box<dyn AsyncAction<S>>),
+}
+
+impl<S> ActionType<S> {
+    pub async fn run(
+        &mut self,
+        delta: &mut tokio::sync::watch::Receiver<f64>,
+        shared: &mut S,
+    ) -> bool {
+        match self {
+            ActionType::Immediate(immediate_action) => immediate_action.run(shared),
+            ActionType::Async(async_action) => async_action.run(delta, shared).await,
+        }
+    }
+
+    pub fn reset(&mut self, shared: &mut S) {
+        match self {
+            ActionType::Immediate(immediate_action) => immediate_action.reset(shared),
+            ActionType::Async(async_action) => async_action.reset(shared),
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            ActionType::Immediate(immediate_action) => immediate_action.name(),
+            ActionType::Async(async_action) => async_action.name(),
+        }
+    }
+}

--- a/async_behaviortree/src/async_action_type.rs
+++ b/async_behaviortree/src/async_action_type.rs
@@ -1,36 +1,36 @@
 use crate::{AsyncAction, ImmediateAction};
 
-pub enum ActionType<S> {
+pub enum AsyncActionType<S> {
     Immediate(Box<dyn ImmediateAction<S>>),
     Async(Box<dyn AsyncAction<S>>),
 }
 
-impl<S> ActionType<S> {
+impl<S> AsyncActionType<S> {
     pub async fn run(
         &mut self,
         delta: &mut tokio::sync::watch::Receiver<f64>,
         shared: &mut S,
     ) -> bool {
         match self {
-            ActionType::Immediate(immediate_action) => {
+            AsyncActionType::Immediate(immediate_action) => {
                 let dt = *delta.borrow_and_update();
                 immediate_action.run(dt, shared)
             }
-            ActionType::Async(async_action) => async_action.run(delta, shared).await,
+            AsyncActionType::Async(async_action) => async_action.run(delta, shared).await,
         }
     }
 
     pub fn reset(&mut self, shared: &mut S) {
         match self {
-            ActionType::Immediate(immediate_action) => immediate_action.reset(shared),
-            ActionType::Async(async_action) => async_action.reset(shared),
+            AsyncActionType::Immediate(immediate_action) => immediate_action.reset(shared),
+            AsyncActionType::Async(async_action) => async_action.reset(shared),
         }
     }
 
     pub fn name(&self) -> &'static str {
         match self {
-            ActionType::Immediate(immediate_action) => immediate_action.name(),
-            ActionType::Async(async_action) => async_action.name(),
+            AsyncActionType::Immediate(immediate_action) => immediate_action.name(),
+            AsyncActionType::Async(async_action) => async_action.name(),
         }
     }
 }

--- a/async_behaviortree/src/async_action_type.rs
+++ b/async_behaviortree/src/async_action_type.rs
@@ -1,4 +1,6 @@
-use crate::{AsyncAction, ImmediateAction};
+use behaviortree_common::ImmediateAction;
+
+use crate::AsyncAction;
 
 pub enum AsyncActionType<S> {
     Immediate(Box<dyn ImmediateAction<S>>),

--- a/async_behaviortree/src/async_behavior_interface.rs
+++ b/async_behaviortree/src/async_behavior_interface.rs
@@ -1,18 +1,3 @@
-pub trait ImmediateAction<S> {
-    /// Runs the action in a single tick
-    ///
-    /// Cannot return `Status::Running`
-    /// true == `Status::Success`
-    /// false == `Status::Failure`
-    fn run(&mut self, delta: f64, shared: &mut S) -> bool;
-
-    /// Resets the current action to its initial/newly created state
-    fn reset(&mut self, shared: &mut S);
-
-    /// Identify your action
-    fn name(&self) -> &'static str;
-}
-
 #[async_trait::async_trait(?Send)]
 pub trait AsyncAction<S> {
     /// Asynchronously runs the action till completion
@@ -36,6 +21,8 @@ pub trait AsyncAction<S> {
 // TODO, Shift this also
 #[cfg(test)]
 pub mod test_async_behavior_interface {
+    use behaviortree_common::ImmediateAction;
+
     use crate::async_action_type::AsyncActionType;
 
     use super::*;

--- a/async_behaviortree/src/async_behavior_interface.rs
+++ b/async_behaviortree/src/async_behavior_interface.rs
@@ -4,7 +4,7 @@ pub trait ImmediateAction<S> {
     /// Cannot return `Status::Running`
     /// true == `Status::Success`
     /// false == `Status::Failure`
-    fn run(&mut self, shared: &mut S) -> bool;
+    fn run(&mut self, delta: f64, shared: &mut S) -> bool;
 
     /// Resets the current action to its initial/newly created state
     fn reset(&mut self, shared: &mut S);
@@ -51,11 +51,11 @@ pub mod test_async_behavior_interface {
     }
 
     impl<S> ImmediateAction<S> for GenericTestImmediateAction {
-        fn run(&mut self, shared: &mut S) -> bool {
+        fn run(&mut self, _delta: f64, _shared: &mut S) -> bool {
             self.status
         }
 
-        fn reset(&mut self, shared: &mut S) {}
+        fn reset(&mut self, _shared: &mut S) {}
 
         fn name(&self) -> &'static str {
             self.name

--- a/async_behaviortree/src/async_behavior_interface.rs
+++ b/async_behaviortree/src/async_behavior_interface.rs
@@ -36,7 +36,7 @@ pub trait AsyncAction<S> {
 // TODO, Shift this also
 #[cfg(test)]
 pub mod test_async_behavior_interface {
-    use crate::action_type::ActionType;
+    use crate::async_action_type::AsyncActionType;
 
     use super::*;
 
@@ -117,22 +117,22 @@ pub mod test_async_behavior_interface {
         FailureAfter { times: usize },
     }
 
-    impl<S> Into<ActionType<S>> for TestAction {
-        fn into(self) -> ActionType<S> {
+    impl<S> Into<AsyncActionType<S>> for TestAction {
+        fn into(self) -> AsyncActionType<S> {
             match self {
                 TestAction::Success => {
                     let action = Box::new(GenericTestImmediateAction {
                         name: "Success",
                         status: true,
                     });
-                    ActionType::Immediate(action)
+                    AsyncActionType::Immediate(action)
                 }
                 TestAction::Failure => {
                     let action = Box::new(GenericTestImmediateAction {
                         name: "Failure",
                         status: false,
                     });
-                    ActionType::Immediate(action)
+                    AsyncActionType::Immediate(action)
                 }
                 TestAction::SuccessAfter { times } => {
                     let action = Box::new(GenericTestAsyncAction::new(
@@ -140,7 +140,7 @@ pub mod test_async_behavior_interface {
                         true,
                         times + 1,
                     ));
-                    ActionType::Async(action)
+                    AsyncActionType::Async(action)
                 }
                 TestAction::FailureAfter { times } => {
                     let action = Box::new(GenericTestAsyncAction::new(
@@ -148,7 +148,7 @@ pub mod test_async_behavior_interface {
                         false,
                         times + 1,
                     ));
-                    ActionType::Async(action)
+                    AsyncActionType::Async(action)
                 }
             }
         }

--- a/async_behaviortree/src/async_behaviortree.rs
+++ b/async_behaviortree/src/async_behaviortree.rs
@@ -3,9 +3,8 @@ use std::future::Future;
 use behaviortree_common::Behavior;
 use behaviortree_common::State;
 
-use crate::AsyncChild;
-
-use crate::ToAsyncAction;
+use crate::action_type::ActionType;
+use crate::async_child::AsyncChild;
 
 pub enum AsyncBehaviorTreePolicy {
     /// Resets/Reloads the behavior tree once it is completed
@@ -44,7 +43,7 @@ impl AsyncBehaviorTree {
         mut shared: S,
     ) -> (impl Future<Output = ()>, AsyncBehaviorController)
     where
-        A: ToAsyncAction<S>,
+        A: Into<ActionType<S>>,
         S: 'static,
     {
         let mut child = AsyncChild::from_behavior(behavior);
@@ -122,7 +121,7 @@ mod tests {
     use tokio::select;
     use tokio_stream::StreamExt;
 
-    use crate::test_async_behavior_interface::{TestAction, TestShared, DELTA};
+    use crate::test_async_behavior_interface::{DELTA, TestAction, TestShared};
 
     #[test]
     fn test_async_behaviortree() {

--- a/async_behaviortree/src/async_behaviortree.rs
+++ b/async_behaviortree/src/async_behaviortree.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use behaviortree_common::Behavior;
 use behaviortree_common::State;
 
-use crate::action_type::ActionType;
+use crate::async_action_type::AsyncActionType;
 use crate::async_child::AsyncChild;
 
 pub enum AsyncBehaviorTreePolicy {
@@ -43,7 +43,7 @@ impl AsyncBehaviorTree {
         mut shared: S,
     ) -> (impl Future<Output = ()>, AsyncBehaviorController)
     where
-        A: Into<ActionType<S>>,
+        A: Into<AsyncActionType<S>>,
         S: 'static,
     {
         let mut child = AsyncChild::from_behavior(behavior);

--- a/async_behaviortree/src/async_child.rs
+++ b/async_behaviortree/src/async_child.rs
@@ -1,24 +1,25 @@
 use behaviortree_common::{Behavior, State, Status};
 
-use crate::{
-    behavior_nodes::{AsyncInvertState, AsyncSelectState, AsyncSequenceState, AsyncWaitState},
-    AsyncAction, ToAsyncAction,
+use crate::action_type::ActionType;
+
+use crate::behavior_nodes::{
+    AsyncInvertState, AsyncSelectState, AsyncSequenceState, AsyncWaitState,
 };
 
 pub struct AsyncChild<S> {
-    action: Box<dyn AsyncAction<S>>,
+    action_type: ActionType<S>,
     status: tokio::sync::watch::Sender<Option<Status>>,
     state: State,
 }
 
 impl<S> AsyncChild<S> {
     pub fn new(
-        action: Box<dyn AsyncAction<S>>,
+        action_type: ActionType<S>,
         status: tokio::sync::watch::Sender<Option<Status>>,
         state: State,
     ) -> Self {
         Self {
-            action,
+            action_type,
             status,
             state,
         }
@@ -26,19 +27,20 @@ impl<S> AsyncChild<S> {
 
     pub fn from_behavior<A>(behavior: Behavior<A>) -> Self
     where
-        A: ToAsyncAction<S>,
+        A: Into<ActionType<S>>,
         S: 'static,
     {
         match behavior {
             Behavior::Action(action) => {
-                let action = action.to_async_action();
+                let action = action.into();
 
                 let (tx, rx) = tokio::sync::watch::channel(None);
                 let state = State::NoChild(action.name(), rx);
                 Self::new(action, tx, state)
             }
             Behavior::Wait(target) => {
-                let action: Box<dyn AsyncAction<S>> = Box::new(AsyncWaitState::new(target));
+                let action = Box::new(AsyncWaitState::new(target));
+                let action = ActionType::Async(action);
 
                 let (tx, rx) = tokio::sync::watch::channel(None);
                 let state = State::NoChild(action.name(), rx);
@@ -49,6 +51,7 @@ impl<S> AsyncChild<S> {
                 let child_state = child.state();
 
                 let action = Box::new(AsyncInvertState::new(child));
+                let action = ActionType::Async(action);
 
                 let (tx, rx) = tokio::sync::watch::channel(None);
                 let state = State::SingleChild(action.name(), rx, child_state.into());
@@ -63,6 +66,7 @@ impl<S> AsyncChild<S> {
                 let children_state = std::rc::Rc::from_iter(children_state);
 
                 let action = Box::new(AsyncSequenceState::new(children));
+                let action = ActionType::Async(action);
 
                 let (tx, rx) = tokio::sync::watch::channel(None);
                 let state = State::MultipleChildren(action.name(), rx, children_state);
@@ -77,6 +81,7 @@ impl<S> AsyncChild<S> {
                 let children_state = std::rc::Rc::from_iter(children_state);
 
                 let action = Box::new(AsyncSelectState::new(children));
+                let action = ActionType::Async(action);
 
                 let (tx, rx) = tokio::sync::watch::channel(None);
                 let state = State::MultipleChildren(action.name(), rx, children_state);
@@ -91,7 +96,7 @@ impl<S> AsyncChild<S> {
         shared: &mut S,
     ) -> bool {
         let _ignore = self.status.send(Some(Status::Running));
-        let success = self.action.run(delta, shared).await;
+        let success = self.action_type.run(delta, shared).await;
         let status = if success {
             Status::Success
         } else {
@@ -105,7 +110,7 @@ impl<S> AsyncChild<S> {
         if self.status.borrow().is_none() {
             return;
         }
-        self.action.reset(shared);
+        self.action_type.reset(shared);
         let _ignore = self.status.send(None);
     }
 
@@ -118,7 +123,7 @@ impl<S> AsyncChild<S> {
 mod tests {
     use ticked_async_executor::TickedAsyncExecutor;
 
-    use crate::test_async_behavior_interface::{TestAction, TestShared, DELTA};
+    use crate::test_async_behavior_interface::{DELTA, TestAction, TestShared};
 
     use super::*;
 

--- a/async_behaviortree/src/behavior_nodes/invert_node.rs
+++ b/async_behaviortree/src/behavior_nodes/invert_node.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::{AsyncAction, AsyncChild};
+use crate::{AsyncAction, async_child::AsyncChild};
 
 pub struct AsyncInvertState<S> {
     child: AsyncChild<S>,
@@ -42,10 +42,8 @@ impl<S> AsyncAction<S> for AsyncInvertState<S> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        test_async_behavior_interface::{TestAction, TestShared, DELTA},
-        AsyncChild,
-    };
+    use super::*;
+    use crate::test_async_behavior_interface::{DELTA, TestAction, TestShared};
     use behaviortree_common::Behavior;
     use ticked_async_executor::TickedAsyncExecutor;
 

--- a/async_behaviortree/src/behavior_nodes/select_node.rs
+++ b/async_behaviortree/src/behavior_nodes/select_node.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::{AsyncAction, AsyncChild};
+use crate::{AsyncAction, async_child::AsyncChild};
 
 pub struct AsyncSelectState<S> {
     children: Vec<AsyncChild<S>>,
@@ -59,7 +59,7 @@ mod tests {
     use behaviortree_common::Behavior;
     use ticked_async_executor::TickedAsyncExecutor;
 
-    use crate::test_async_behavior_interface::{TestAction, TestShared, DELTA};
+    use crate::test_async_behavior_interface::{DELTA, TestAction, TestShared};
 
     use super::*;
 

--- a/async_behaviortree/src/behavior_nodes/sequence_node.rs
+++ b/async_behaviortree/src/behavior_nodes/sequence_node.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::{AsyncAction, AsyncChild};
+use crate::{AsyncAction, async_child::AsyncChild};
 
 pub struct AsyncSequenceState<S> {
     children: Vec<AsyncChild<S>>,
@@ -61,7 +61,7 @@ mod tests {
     use behaviortree_common::Behavior;
     use ticked_async_executor::TickedAsyncExecutor;
 
-    use crate::test_async_behavior_interface::{TestAction, TestShared, DELTA};
+    use crate::test_async_behavior_interface::{DELTA, TestAction, TestShared};
 
     use super::*;
 

--- a/async_behaviortree/src/behavior_nodes/wait_node.rs
+++ b/async_behaviortree/src/behavior_nodes/wait_node.rs
@@ -53,7 +53,7 @@ mod tests {
     use ticked_async_executor::TickedAsyncExecutor;
 
     use super::*;
-    use crate::test_async_behavior_interface::{TestShared, DELTA};
+    use crate::test_async_behavior_interface::{DELTA, TestShared};
 
     #[test]
     fn test_wait_success() {
@@ -120,6 +120,17 @@ mod tests {
             .detach();
 
         executor.tick(DELTA, None);
+        let mut r = executor.tick_channel();
+        let mut r1 = r.clone();
+        executor.tick(DELTA, None);
+        assert!(r.has_changed().unwrap());
+        assert!(r1.has_changed().unwrap());
+        r.borrow_and_update();
+        assert!(!r.has_changed().unwrap());
+        assert!(r1.has_changed().unwrap());
+        r1.borrow_and_update();
+        assert!(!r.has_changed().unwrap());
+        assert!(!r1.has_changed().unwrap());
         drop(executor);
     }
 }

--- a/async_behaviortree/src/behavior_nodes/wait_node.rs
+++ b/async_behaviortree/src/behavior_nodes/wait_node.rs
@@ -120,17 +120,6 @@ mod tests {
             .detach();
 
         executor.tick(DELTA, None);
-        let mut r = executor.tick_channel();
-        let mut r1 = r.clone();
-        executor.tick(DELTA, None);
-        assert!(r.has_changed().unwrap());
-        assert!(r1.has_changed().unwrap());
-        r.borrow_and_update();
-        assert!(!r.has_changed().unwrap());
-        assert!(r1.has_changed().unwrap());
-        r1.borrow_and_update();
-        assert!(!r.has_changed().unwrap());
-        assert!(!r1.has_changed().unwrap());
         drop(executor);
     }
 }

--- a/async_behaviortree/src/lib.rs
+++ b/async_behaviortree/src/lib.rs
@@ -1,3 +1,5 @@
+pub use behaviortree_common::*;
+
 mod async_behavior_interface;
 pub use async_behavior_interface::*;
 

--- a/async_behaviortree/src/lib.rs
+++ b/async_behaviortree/src/lib.rs
@@ -1,11 +1,13 @@
 mod async_behavior_interface;
 pub use async_behavior_interface::*;
 
-mod async_child;
-pub use async_child::*;
-
 mod async_behaviortree;
 pub use async_behaviortree::*;
 
 // Not meant to be used externally
+mod action_type;
+
+// TODO, Rename this
+mod async_child;
+
 mod behavior_nodes;

--- a/async_behaviortree/src/lib.rs
+++ b/async_behaviortree/src/lib.rs
@@ -5,9 +5,6 @@ mod async_behaviortree;
 pub use async_behaviortree::*;
 
 // Not meant to be used externally
-mod action_type;
-
-// TODO, Rename this
+mod async_action_type;
 mod async_child;
-
 mod behavior_nodes;

--- a/async_behaviortree/src/lib.rs
+++ b/async_behaviortree/src/lib.rs
@@ -1,10 +1,12 @@
 mod async_behavior_interface;
 pub use async_behavior_interface::*;
 
+mod async_action_type;
+pub use async_action_type::*;
+
 mod async_behaviortree;
 pub use async_behaviortree::*;
 
 // Not meant to be used externally
-mod async_action_type;
 mod async_child;
 mod behavior_nodes;

--- a/behaviortree/Cargo.toml
+++ b/behaviortree/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "behaviortree"
-version = "0.1.3"
-edition = "2021"
+version = "0.1.4"
+edition = "2024"
 
 [dependencies]
 serde = { workspace = true }

--- a/behaviortree/examples/simple.rs
+++ b/behaviortree/examples/simple.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, rc::Rc, sync::RwLock};
 
-use behaviortree::{BehaviorTree, SyncAction, ToAction};
+use behaviortree::{ActionType, BehaviorTree, SyncAction};
 use behaviortree_common::{Behavior, Status};
 
 #[derive(Debug, serde::Serialize)]
@@ -28,12 +28,17 @@ enum Operation {
     Subtract(Input<usize>, Input<usize>, Output),
 }
 
-// Convert Operation data to functionality
-impl ToAction<OperationShared> for Operation {
-    fn to_action(self) -> Box<dyn SyncAction<OperationShared>> {
+impl Into<ActionType<OperationShared>> for Operation {
+    fn into(self) -> ActionType<OperationShared> {
         match self {
-            Operation::Add(a, b, c) => Box::new(AddState(a, b, c)),
-            Operation::Subtract(a, b, c) => Box::new(SubState(a, b, c)),
+            Operation::Add(a, b, c) => {
+                let action = Box::new(AddState(a, b, c));
+                ActionType::Sync(action)
+            }
+            Operation::Subtract(a, b, c) => {
+                let action = Box::new(SubState(a, b, c));
+                ActionType::Sync(action)
+            }
         }
     }
 }

--- a/behaviortree/examples/simple.rs
+++ b/behaviortree/examples/simple.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, rc::Rc, sync::RwLock};
 
-use behaviortree::{Action, Behavior, BehaviorTree, Status, ToAction};
+use behaviortree::{Behavior, BehaviorTree, Status, SyncAction, ToAction};
 
 #[derive(Debug, serde::Serialize)]
 enum Input<T> {
@@ -29,7 +29,7 @@ enum Operation {
 
 // Convert Operation data to functionality
 impl ToAction<OperationShared> for Operation {
-    fn to_action(self) -> Box<dyn Action<OperationShared>> {
+    fn to_action(self) -> Box<dyn SyncAction<OperationShared>> {
         match self {
             Operation::Add(a, b, c) => Box::new(AddState(a, b, c)),
             Operation::Subtract(a, b, c) => Box::new(SubState(a, b, c)),
@@ -38,7 +38,7 @@ impl ToAction<OperationShared> for Operation {
 }
 
 struct AddState(Input<usize>, Input<usize>, Output);
-impl Action<OperationShared> for AddState {
+impl SyncAction<OperationShared> for AddState {
     fn tick(&mut self, _dt: f64, shared: &mut OperationShared) -> Status {
         let mut blackboard = shared.blackboard.write().unwrap();
 
@@ -73,7 +73,7 @@ impl Action<OperationShared> for AddState {
 }
 
 struct SubState(Input<usize>, Input<usize>, Output);
-impl Action<OperationShared> for SubState {
+impl SyncAction<OperationShared> for SubState {
     fn tick(&mut self, _dt: f64, shared: &mut OperationShared) -> Status {
         let mut blackboard = shared.blackboard.write().unwrap();
 

--- a/behaviortree/examples/simple.rs
+++ b/behaviortree/examples/simple.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, rc::Rc, sync::RwLock};
 
-use behaviortree::{Behavior, BehaviorTree, Status, SyncAction, ToAction};
+use behaviortree::{BehaviorTree, SyncAction, ToAction};
+use behaviortree_common::{Behavior, Status};
 
 #[derive(Debug, serde::Serialize)]
 enum Input<T> {

--- a/behaviortree/src/action_type.rs
+++ b/behaviortree/src/action_type.rs
@@ -1,0 +1,38 @@
+use behaviortree_common::{ImmediateAction, Status};
+
+use crate::SyncAction;
+
+pub enum ActionType<S> {
+    Immediate(Box<dyn ImmediateAction<S>>),
+    Sync(Box<dyn SyncAction<S>>),
+}
+
+impl<S> ActionType<S> {
+    pub fn tick(&mut self, delta: f64, shared: &mut S) -> Status {
+        match self {
+            ActionType::Immediate(immediate_action) => {
+                let status = immediate_action.run(delta, shared);
+                if status {
+                    Status::Success
+                } else {
+                    Status::Failure
+                }
+            }
+            ActionType::Sync(sync_action) => sync_action.tick(delta, shared),
+        }
+    }
+
+    pub fn reset(&mut self, shared: &mut S) {
+        match self {
+            ActionType::Immediate(immediate_action) => immediate_action.reset(shared),
+            ActionType::Sync(sync_action) => sync_action.reset(shared),
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            ActionType::Immediate(immediate_action) => immediate_action.name(),
+            ActionType::Sync(sync_action) => sync_action.name(),
+        }
+    }
+}

--- a/behaviortree/src/behavior_interface.rs
+++ b/behaviortree/src/behavior_interface.rs
@@ -1,4 +1,4 @@
-use crate::Status;
+use behaviortree_common::Status;
 
 /// Modelled after the `std::future::Future` trait
 pub trait SyncAction<S> {

--- a/behaviortree/src/behavior_interface.rs
+++ b/behaviortree/src/behavior_interface.rs
@@ -1,7 +1,7 @@
 use crate::Status;
 
 /// Modelled after the `std::future::Future` trait
-pub trait Action<S> {
+pub trait SyncAction<S> {
     /// Ticks the action once.
     ///
     /// User implementation must ensure that calls to `tick` are non-blocking.
@@ -20,7 +20,7 @@ pub trait Action<S> {
 }
 
 pub trait ToAction<S> {
-    fn to_action(self) -> Box<dyn Action<S>>;
+    fn to_action(self) -> Box<dyn SyncAction<S>>;
 }
 
 #[cfg(test)]
@@ -48,7 +48,7 @@ pub mod test_behavior_interface {
         }
     }
 
-    impl<S> Action<S> for GenericTestAction {
+    impl<S> SyncAction<S> for GenericTestAction {
         #[tracing::instrument(level = "trace", name = "GenericTestAction", skip_all, ret)]
         fn tick(&mut self, _dt: f64, _shared: &mut S) -> Status {
             let mut status = if self.status {
@@ -81,7 +81,7 @@ pub mod test_behavior_interface {
     }
 
     impl ToAction<TestShared> for TestAction {
-        fn to_action(self) -> Box<dyn Action<TestShared>> {
+        fn to_action(self) -> Box<dyn SyncAction<TestShared>> {
             match self {
                 TestAction::Success => Box::new(GenericTestAction::new("Success".into(), true, 1)),
                 TestAction::Failure => Box::new(GenericTestAction::new("Failure".into(), false, 1)),

--- a/behaviortree/src/behavior_nodes/invert_node.rs
+++ b/behaviortree/src/behavior_nodes/invert_node.rs
@@ -1,4 +1,4 @@
-use crate::{child::Child, Action, Status};
+use crate::{child::Child, Status, SyncAction};
 
 pub struct InvertState<S> {
     child: Child<S>,
@@ -14,7 +14,7 @@ impl<S> InvertState<S> {
     }
 }
 
-impl<S> Action<S> for InvertState<S> {
+impl<S> SyncAction<S> for InvertState<S> {
     #[tracing::instrument(level = "trace", name = "Invert", skip_all, ret)]
     fn tick(&mut self, delta: f64, shared: &mut S) -> Status {
         match self.completed {

--- a/behaviortree/src/behavior_nodes/invert_node.rs
+++ b/behaviortree/src/behavior_nodes/invert_node.rs
@@ -1,4 +1,6 @@
-use crate::{child::Child, Status, SyncAction};
+use behaviortree_common::Status;
+
+use crate::{child::Child, SyncAction};
 
 pub struct InvertState<S> {
     child: Child<S>,
@@ -47,10 +49,9 @@ impl<S> SyncAction<S> for InvertState<S> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        test_behavior_interface::{TestAction, TestShared},
-        Behavior,
-    };
+    use behaviortree_common::Behavior;
+
+    use crate::test_behavior_interface::{TestAction, TestShared};
 
     use super::*;
 

--- a/behaviortree/src/behavior_nodes/select_node.rs
+++ b/behaviortree/src/behavior_nodes/select_node.rs
@@ -1,4 +1,6 @@
-use crate::{child::Child, Status, SyncAction};
+use behaviortree_common::Status;
+
+use crate::{child::Child, SyncAction};
 
 pub struct SelectState<S> {
     children: Vec<Child<S>>,
@@ -60,10 +62,9 @@ impl<S> SyncAction<S> for SelectState<S> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        test_behavior_interface::{TestAction, TestShared},
-        Behavior,
-    };
+    use behaviortree_common::Behavior;
+
+    use crate::test_behavior_interface::{TestAction, TestShared};
 
     use super::*;
 

--- a/behaviortree/src/behavior_nodes/select_node.rs
+++ b/behaviortree/src/behavior_nodes/select_node.rs
@@ -1,4 +1,4 @@
-use crate::{child::Child, Action, Status};
+use crate::{child::Child, Status, SyncAction};
 
 pub struct SelectState<S> {
     children: Vec<Child<S>>,
@@ -17,7 +17,7 @@ impl<S> SelectState<S> {
     }
 }
 
-impl<S> Action<S> for SelectState<S> {
+impl<S> SyncAction<S> for SelectState<S> {
     #[tracing::instrument(level = "trace", name = "Select", skip_all, ret)]
     fn tick(&mut self, dt: f64, shared: &mut S) -> Status {
         match self.completed {

--- a/behaviortree/src/behavior_nodes/sequence_node.rs
+++ b/behaviortree/src/behavior_nodes/sequence_node.rs
@@ -1,4 +1,6 @@
-use crate::{child::Child, Status, SyncAction};
+use behaviortree_common::Status;
+
+use crate::{child::Child, SyncAction};
 
 pub struct SequenceState<S> {
     children: Vec<Child<S>>,
@@ -60,11 +62,10 @@ impl<S> SyncAction<S> for SequenceState<S> {
 
 #[cfg(test)]
 mod tests {
+    use behaviortree_common::Behavior;
+
     use super::*;
-    use crate::{
-        test_behavior_interface::{TestAction, TestShared},
-        Behavior, Status,
-    };
+    use crate::test_behavior_interface::{TestAction, TestShared};
 
     #[test]
     fn test_sequence_success() {

--- a/behaviortree/src/behavior_nodes/sequence_node.rs
+++ b/behaviortree/src/behavior_nodes/sequence_node.rs
@@ -1,4 +1,4 @@
-use crate::{child::Child, Action, Status};
+use crate::{child::Child, Status, SyncAction};
 
 pub struct SequenceState<S> {
     children: Vec<Child<S>>,
@@ -17,7 +17,7 @@ impl<S> SequenceState<S> {
     }
 }
 
-impl<S> Action<S> for SequenceState<S> {
+impl<S> SyncAction<S> for SequenceState<S> {
     #[tracing::instrument(level = "trace", name = "Sequence", skip_all, ret)]
     fn tick(&mut self, dt: f64, shared: &mut S) -> Status {
         match self.completed {

--- a/behaviortree/src/behavior_nodes/wait_node.rs
+++ b/behaviortree/src/behavior_nodes/wait_node.rs
@@ -1,4 +1,6 @@
-use crate::{Status, SyncAction};
+use behaviortree_common::Status;
+
+use crate::SyncAction;
 
 pub struct WaitState {
     target: f64,

--- a/behaviortree/src/behavior_nodes/wait_node.rs
+++ b/behaviortree/src/behavior_nodes/wait_node.rs
@@ -1,11 +1,11 @@
-use crate::{Action, Status};
+use crate::{Status, SyncAction};
 
 pub struct WaitState {
     target: f64,
     elapsed: f64,
 }
 
-impl<S> Action<S> for WaitState {
+impl<S> SyncAction<S> for WaitState {
     #[tracing::instrument(level = "trace", name = "Wait", skip_all, ret)]
     fn tick(&mut self, dt: f64, _shared: &mut S) -> Status {
         match self.elapsed >= self.target {
@@ -54,7 +54,7 @@ mod tests {
         let mut shared = TestShared::default();
 
         let mut wait = WaitState::new(2.0);
-        let wait_ref_mut: &mut dyn Action<TestShared> = &mut wait;
+        let wait_ref_mut: &mut dyn SyncAction<TestShared> = &mut wait;
 
         let status = wait_ref_mut.tick(1.0, &mut shared);
         assert_eq!(status, Status::Running);

--- a/behaviortree/src/behaviortree.rs
+++ b/behaviortree/src/behaviortree.rs
@@ -1,6 +1,6 @@
 use behaviortree_common::{Behavior, State, Status};
 
-use crate::{child::Child, ToAction};
+use crate::{action_type::ActionType, child::Child};
 
 pub enum BehaviorTreePolicy {
     /// Resets/Reloads the behavior tree once it is completed
@@ -18,7 +18,7 @@ pub struct BehaviorTree<S> {
 impl<S> BehaviorTree<S> {
     pub fn new<A>(behavior: Behavior<A>, behavior_policy: BehaviorTreePolicy, shared: S) -> Self
     where
-        A: ToAction<S>,
+        A: Into<ActionType<S>>,
         S: 'static,
     {
         let child = Child::from_behavior(behavior);

--- a/behaviortree/src/behaviortree.rs
+++ b/behaviortree/src/behaviortree.rs
@@ -1,4 +1,6 @@
-use crate::{child::Child, Behavior, State, Status, ToAction};
+use behaviortree_common::{Behavior, State, Status};
+
+use crate::{child::Child, ToAction};
 
 pub enum BehaviorTreePolicy {
     /// Resets/Reloads the behavior tree once it is completed

--- a/behaviortree/src/child.rs
+++ b/behaviortree/src/child.rs
@@ -1,16 +1,16 @@
 use behaviortree_common::{Behavior, State, Status};
 
-use crate::{behavior_nodes::*, Action, ToAction};
+use crate::{behavior_nodes::*, SyncAction, ToAction};
 
 pub struct Child<S> {
-    action: Box<dyn Action<S>>,
+    action: Box<dyn SyncAction<S>>,
     status: tokio::sync::watch::Sender<Option<Status>>,
     state: State,
 }
 
 impl<S> Child<S> {
     pub fn new(
-        action: Box<dyn Action<S>>,
+        action: Box<dyn SyncAction<S>>,
         status: tokio::sync::watch::Sender<Option<Status>>,
         state: State,
     ) -> Self {
@@ -35,7 +35,7 @@ impl<S> Child<S> {
                 Self::new(action, tx, state)
             }
             Behavior::Wait(target) => {
-                let action: Box<dyn Action<S>> = Box::new(WaitState::new(target));
+                let action: Box<dyn SyncAction<S>> = Box::new(WaitState::new(target));
                 let (tx, rx) = tokio::sync::watch::channel(None);
                 let state = State::NoChild(action.name(), rx);
 

--- a/behaviortree/src/child.rs
+++ b/behaviortree/src/child.rs
@@ -1,16 +1,16 @@
 use behaviortree_common::{Behavior, State, Status};
 
-use crate::{behavior_nodes::*, SyncAction, ToAction};
+use crate::{action_type::ActionType, behavior_nodes::*};
 
 pub struct Child<S> {
-    action: Box<dyn SyncAction<S>>,
+    action: ActionType<S>,
     status: tokio::sync::watch::Sender<Option<Status>>,
     state: State,
 }
 
 impl<S> Child<S> {
     pub fn new(
-        action: Box<dyn SyncAction<S>>,
+        action: ActionType<S>,
         status: tokio::sync::watch::Sender<Option<Status>>,
         state: State,
     ) -> Self {
@@ -23,19 +23,21 @@ impl<S> Child<S> {
 
     pub fn from_behavior<A>(behavior: Behavior<A>) -> Self
     where
-        A: ToAction<S>,
+        A: Into<ActionType<S>>,
         S: 'static,
     {
         match behavior {
             Behavior::Action(action) => {
-                let action = action.to_action();
+                let action = action.into();
                 let (tx, rx) = tokio::sync::watch::channel(None);
                 let state = State::NoChild(action.name(), rx);
 
                 Self::new(action, tx, state)
             }
             Behavior::Wait(target) => {
-                let action: Box<dyn SyncAction<S>> = Box::new(WaitState::new(target));
+                let action = Box::new(WaitState::new(target));
+                let action = ActionType::Sync(action);
+
                 let (tx, rx) = tokio::sync::watch::channel(None);
                 let state = State::NoChild(action.name(), rx);
 
@@ -45,11 +47,13 @@ impl<S> Child<S> {
                 let child = Child::from_behavior(*child);
                 let child_state = child.state();
 
-                let action = InvertState::new(child);
+                let action = Box::new(InvertState::new(child));
+                let action = ActionType::Sync(action);
+
                 let (tx, rx) = tokio::sync::watch::channel(None);
                 let state = State::SingleChild(action.name(), rx, child_state.into());
 
-                Self::new(Box::new(action), tx, state)
+                Self::new(action, tx, state)
             }
             Behavior::Sequence(children) => {
                 let children = children
@@ -59,11 +63,13 @@ impl<S> Child<S> {
                 let children_states = children.iter().map(|child| child.state());
                 let children_states = std::rc::Rc::from_iter(children_states);
 
-                let action = SequenceState::new(children);
+                let action = Box::new(SequenceState::new(children));
+                let action = ActionType::Sync(action);
+
                 let (tx, rx) = tokio::sync::watch::channel(None);
                 let state = State::MultipleChildren(action.name(), rx, children_states);
 
-                Self::new(Box::new(action), tx, state)
+                Self::new(action, tx, state)
             }
             Behavior::Select(children) => {
                 let children = children
@@ -73,11 +79,13 @@ impl<S> Child<S> {
                 let children_states = children.iter().map(|child| child.state());
                 let children_states = std::rc::Rc::from_iter(children_states);
 
-                let action = SelectState::new(children);
+                let action = Box::new(SelectState::new(children));
+                let action = ActionType::Sync(action);
+
                 let (tx, rx) = tokio::sync::watch::channel(None);
                 let state = State::MultipleChildren(action.name(), rx, children_states);
 
-                Self::new(Box::new(action), tx, state)
+                Self::new(action, tx, state)
             }
         }
     }

--- a/behaviortree/src/lib.rs
+++ b/behaviortree/src/lib.rs
@@ -1,10 +1,12 @@
 mod behavior_interface;
 pub use behavior_interface::*;
 
+mod action_type;
+pub use action_type::*;
+
 mod behaviortree;
 pub use behaviortree::*;
 
 // Not meant to be used externally
-mod action_type;
 mod behavior_nodes;
 mod child;

--- a/behaviortree/src/lib.rs
+++ b/behaviortree/src/lib.rs
@@ -1,5 +1,3 @@
-pub use behaviortree_common::*;
-
 mod behavior_interface;
 pub use behavior_interface::*;
 
@@ -7,6 +5,6 @@ mod behaviortree;
 pub use behaviortree::*;
 
 // Not meant to be used externally
-mod child;
-
+mod action_type;
 mod behavior_nodes;
+mod child;

--- a/behaviortree/src/lib.rs
+++ b/behaviortree/src/lib.rs
@@ -1,3 +1,5 @@
+pub use behaviortree_common::*;
+
 mod behavior_interface;
 pub use behavior_interface::*;
 

--- a/behaviortree_common/src/behavior_interface.rs
+++ b/behaviortree_common/src/behavior_interface.rs
@@ -1,0 +1,14 @@
+pub trait ImmediateAction<S> {
+    /// Runs the action in a single tick
+    ///
+    /// Cannot return `Status::Running`
+    /// true == `Status::Success`
+    /// false == `Status::Failure`
+    fn run(&mut self, delta: f64, shared: &mut S) -> bool;
+
+    /// Resets the current action to its initial/newly created state
+    fn reset(&mut self, shared: &mut S);
+
+    /// Identify your action
+    fn name(&self) -> &'static str;
+}

--- a/behaviortree_common/src/lib.rs
+++ b/behaviortree_common/src/lib.rs
@@ -4,5 +4,8 @@ pub use status::*;
 mod behavior;
 pub use behavior::*;
 
+mod behavior_interface;
+pub use behavior_interface::*;
+
 mod state;
 pub use state::*;


### PR DESCRIPTION
# Main
- ImmediateAction trait
- User defined action now needs to implement `Into<ActionType>` for BehaviorTree or `Into<AsyncAction>` for AsyncBehaviorTree

# Misc
- Updated versions and rust edition to 2024
- Updated README diagram