### PR TITLE
Behavior Node: Loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ tokio = { version = "1", default-features = false, features = [
     "macros",
     "sync",
 ] }
+tokio-util = "0.7"
 
 # Tracing
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # behaviortree-rs
 
+# Class Diagram
+
 ```mermaid
 classDiagram
 
@@ -101,10 +103,23 @@ AsyncChild --> AsyncBehaviorTree
 - [x] SyncAction trait
 - [x] AsyncAction trait
 - [ ] Behavior Nodes
-  - [x] Wait
-  - [x] Invert
-  - [x] Sequence
-  - [x] Select
+  - [ ] Action
+    - [x] Wait
+  - [ ] Decorator
+    - [x] Invert
+    - [ ] ForceSuccess
+    - [ ] ForceFailure
+    - [ ] Repeat
+    - [ ] RunTillSuccess
+    - [ ] RunTillFailure
+  - [ ] Control
+    - [x] Sequence
+    - [x] Select
+    - [x] Loop
+    - [ ] ReactiveSequence/WhileTrue
+    - [ ] WhileRunning
+    - [ ] ReactiveSelect/WhileFalse
+    - [ ] Parallel
 - [x] Tracing
   - [x] BehaviorTree
   - [x] AsyncBehaviorTree

--- a/async_behaviortree/Cargo.toml
+++ b/async_behaviortree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async_behaviortree"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]

--- a/async_behaviortree/Cargo.toml
+++ b/async_behaviortree/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 serde = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 
 behaviortree_common = { path = "../behaviortree_common" }

--- a/async_behaviortree/examples/simple_immediate_async.rs
+++ b/async_behaviortree/examples/simple_immediate_async.rs
@@ -78,7 +78,7 @@ impl ImmediateAction<OperationShared> for AddState {
     }
 
     #[tracing::instrument(level = "trace", name = "Add::reset", skip_all)]
-    fn reset(&mut self, _shared: &mut OperationShared) {}
+    fn reset(&mut self, _shared: &OperationShared) {}
 
     fn name(&self) -> &'static str {
         "Add"
@@ -116,7 +116,7 @@ impl ImmediateAction<OperationShared> for SubState {
     }
 
     #[tracing::instrument(level = "trace", name = "Sub::reset", skip_all)]
-    fn reset(&mut self, _shared: &mut OperationShared) {}
+    fn reset(&mut self, _shared: &OperationShared) {}
 
     fn name(&self) -> &'static str {
         "Sub"

--- a/async_behaviortree/src/async_action_type.rs
+++ b/async_behaviortree/src/async_action_type.rs
@@ -16,7 +16,7 @@ impl<S> AsyncActionType<S> {
         }
     }
 
-    pub fn reset(&mut self, shared: &mut S) {
+    pub fn reset(&mut self, shared: &S) {
         match self {
             AsyncActionType::Immediate(immediate_action) => immediate_action.reset(shared),
             AsyncActionType::Async(async_action) => async_action.reset(shared),

--- a/async_behaviortree/src/async_behavior_interface.rs
+++ b/async_behaviortree/src/async_behavior_interface.rs
@@ -7,7 +7,7 @@ pub trait ImmediateAction<S> {
     fn run(&mut self, delta: f64, shared: &S) -> bool;
 
     /// Resets the current action to its initial/newly created state
-    fn reset(&mut self, shared: &mut S);
+    fn reset(&mut self, shared: &S);
 
     /// Identify your action
     fn name(&self) -> &'static str;
@@ -27,7 +27,7 @@ pub trait AsyncAction<S> {
     async fn run(&mut self, delta: tokio::sync::watch::Receiver<f64>, shared: &S) -> bool;
 
     /// Resets the current action to its initial/newly created state
-    fn reset(&mut self, shared: &mut S);
+    fn reset(&mut self, shared: &S);
 
     /// Identify your action
     fn name(&self) -> &'static str;
@@ -55,7 +55,7 @@ pub mod test_async_behavior_interface {
             self.status
         }
 
-        fn reset(&mut self, _shared: &mut S) {}
+        fn reset(&mut self, _shared: &S) {}
 
         fn name(&self) -> &'static str {
             self.name
@@ -96,7 +96,7 @@ pub mod test_async_behavior_interface {
             self.status
         }
 
-        fn reset(&mut self, _shared: &mut S) {
+        fn reset(&mut self, _shared: &S) {
             self.elapsed = 0;
         }
 

--- a/async_behaviortree/src/async_behavior_interface.rs
+++ b/async_behaviortree/src/async_behavior_interface.rs
@@ -113,6 +113,8 @@ pub mod test_async_behavior_interface {
     pub enum TestAction {
         Success,
         Failure,
+        SuccessNamed { name: &'static str },
+        FailureNamed { name: &'static str },
         SuccessAfter { times: usize },
         FailureAfter { times: usize },
     }
@@ -130,6 +132,17 @@ pub mod test_async_behavior_interface {
                 TestAction::Failure => {
                     let action = Box::new(GenericTestImmediateAction {
                         name: "Failure",
+                        status: false,
+                    });
+                    AsyncActionType::Immediate(action)
+                }
+                TestAction::SuccessNamed { name } => {
+                    let action = Box::new(GenericTestImmediateAction { name, status: true });
+                    AsyncActionType::Immediate(action)
+                }
+                TestAction::FailureNamed { name } => {
+                    let action = Box::new(GenericTestImmediateAction {
+                        name,
                         status: false,
                     });
                     AsyncActionType::Immediate(action)

--- a/async_behaviortree/src/async_behavior_interface.rs
+++ b/async_behaviortree/src/async_behavior_interface.rs
@@ -51,10 +51,12 @@ pub mod test_async_behavior_interface {
     }
 
     impl<S> ImmediateAction<S> for GenericTestImmediateAction {
+        #[tracing::instrument(level = "trace", name = "GenericTestImmediateAction::run", fields(name=<GenericTestImmediateAction as ImmediateAction<S>>::name(self)), skip_all, ret)]
         fn run(&mut self, _delta: f64, _shared: &S) -> bool {
             self.status
         }
 
+        #[tracing::instrument(level = "trace", name = "GenericTestImmediateAction::reset", fields(name=<GenericTestImmediateAction as ImmediateAction<S>>::name(self)), skip_all)]
         fn reset(&mut self, _shared: &S) {}
 
         fn name(&self) -> &'static str {
@@ -82,6 +84,7 @@ pub mod test_async_behavior_interface {
 
     #[async_trait::async_trait(?Send)]
     impl<S> AsyncAction<S> for GenericTestAsyncAction {
+        #[tracing::instrument(level = "trace", name = "GenericTestAsyncAction::run", fields(name=<GenericTestAsyncAction as AsyncAction<S>>::name(self)), skip_all, ret)]
         async fn run(&mut self, mut delta: tokio::sync::watch::Receiver<f64>, _shared: &S) -> bool {
             loop {
                 let _r = delta.changed().await.unwrap();
@@ -96,6 +99,7 @@ pub mod test_async_behavior_interface {
             self.status
         }
 
+        #[tracing::instrument(level = "trace", name = "GenericTestAsyncAction::reset", fields(name=<GenericTestAsyncAction as AsyncAction<S>>::name(self)), skip_all)]
         fn reset(&mut self, _shared: &S) {
             self.elapsed = 0;
         }

--- a/async_behaviortree/src/async_behaviortree.rs
+++ b/async_behaviortree/src/async_behaviortree.rs
@@ -81,10 +81,9 @@ mod tests {
 
     #[test]
     fn test_async_behaviortree() {
-        tracing_subscriber::Registry::default()
+        let _ignore = tracing_subscriber::Registry::default()
             .with(tracing_forest::ForestLayer::default())
-            .try_init()
-            .unwrap();
+            .try_init();
 
         let behavior = Behavior::Sequence(vec![
             Behavior::Action(TestAction::Success),
@@ -171,10 +170,9 @@ mod tests {
 
     #[test]
     fn test_async_behaviortree_shutdown() {
-        tracing_subscriber::Registry::default()
+        let _ignore = tracing_subscriber::Registry::default()
             .with(tracing_forest::ForestLayer::default())
-            .try_init()
-            .unwrap();
+            .try_init();
 
         let behavior = Behavior::Sequence(vec![
             Behavior::Invert(Box::new(Behavior::Action(TestAction::Failure))),

--- a/async_behaviortree/src/async_behaviortree.rs
+++ b/async_behaviortree/src/async_behaviortree.rs
@@ -179,7 +179,7 @@ mod tests {
             Behavior::Action(TestAction::Success),
             Behavior::Action(TestAction::Success),
         ]);
-        let behavior = Behavior::Loop(vec![behavior]);
+        let behavior = Behavior::Loop(Box::new(behavior));
 
         let executor = TickedAsyncExecutor::default();
         let shared = TestShared;

--- a/async_behaviortree/src/async_child.rs
+++ b/async_behaviortree/src/async_child.rs
@@ -102,7 +102,7 @@ impl<S> AsyncChild<S> {
         success
     }
 
-    pub fn reset(&mut self, shared: &mut S) {
+    pub fn reset(&mut self, shared: &S) {
         if self.status.borrow().is_none() {
             return;
         }

--- a/async_behaviortree/src/async_child.rs
+++ b/async_behaviortree/src/async_child.rs
@@ -9,6 +9,7 @@ use crate::behavior_nodes::{
 pub struct AsyncChild<S> {
     action_type: AsyncActionType<S>,
     status: tokio::sync::watch::Sender<Option<Status>>,
+    _status_rx: tokio::sync::watch::Receiver<Option<Status>>,
 }
 
 impl<S> AsyncChild<S> {
@@ -16,9 +17,11 @@ impl<S> AsyncChild<S> {
         action_type: AsyncActionType<S>,
         status: tokio::sync::watch::Sender<Option<Status>>,
     ) -> Self {
+        let _status_rx = status.subscribe();
         Self {
             action_type,
             status,
+            _status_rx,
         }
     }
 

--- a/async_behaviortree/src/behavior_nodes/invert_node.rs
+++ b/async_behaviortree/src/behavior_nodes/invert_node.rs
@@ -32,7 +32,7 @@ impl<S> AsyncAction<S> for AsyncInvertState<S> {
     }
 
     #[tracing::instrument(level = "trace", name = "Invert::reset", skip_all, ret)]
-    fn reset(&mut self, shared: &mut S) {
+    fn reset(&mut self, shared: &S) {
         self.child.reset(shared);
         self.completed = false;
     }

--- a/async_behaviortree/src/behavior_nodes/loop_node.rs
+++ b/async_behaviortree/src/behavior_nodes/loop_node.rs
@@ -1,0 +1,121 @@
+use crate::{AsyncAction, async_child::AsyncChild, util::yield_now};
+
+pub struct AsyncLoopState<S> {
+    children: Vec<AsyncChild<S>>,
+}
+
+impl<S> AsyncLoopState<S> {
+    pub fn new(children: Vec<AsyncChild<S>>) -> Self {
+        Self { children }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl<S> AsyncAction<S> for AsyncLoopState<S> {
+    #[tracing::instrument(level = "trace", name = "Loop::run", skip_all, ret)]
+    async fn run(&mut self, delta: tokio::sync::watch::Receiver<f64>, shared: &S) -> bool {
+        loop {
+            for child in self.children.iter_mut() {
+                let child_status = child.run(delta.clone(), shared).await;
+                yield_now().await;
+                if !child_status {
+                    break;
+                }
+            }
+
+            // We reset if all children succeeded
+            self.children.iter_mut().for_each(|child| {
+                child.reset(shared);
+            });
+        }
+    }
+
+    #[tracing::instrument(level = "trace", name = "Loop::reset", skip_all, ret)]
+    fn reset(&mut self, shared: &S) {
+        self.children.iter_mut().for_each(|child| {
+            child.reset(shared);
+        });
+    }
+
+    fn name(&self) -> &'static str {
+        "Loop"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use behaviortree_common::Behavior;
+    use ticked_async_executor::TickedAsyncExecutor;
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    use crate::test_async_behavior_interface::TestAction;
+
+    use super::*;
+
+    #[test]
+    fn test_loop_all_success() {
+        tracing_subscriber::Registry::default()
+            .with(tracing_forest::ForestLayer::default())
+            .try_init()
+            .unwrap();
+
+        let behavior = Behavior::Loop(vec![
+            Behavior::Action(TestAction::Success),
+            Behavior::Action(TestAction::Success),
+            Behavior::Action(TestAction::Success),
+        ]);
+        let (mut async_loop, state) = AsyncChild::from_behavior_with_state(behavior);
+
+        let executor = TickedAsyncExecutor::default();
+        let delta_rx = executor.tick_channel();
+        executor
+            .spawn_local("_", async move {
+                async_loop.run(delta_rx, &()).await;
+            })
+            .detach();
+
+        for i in 0..6 {
+            executor.tick(0.1, None);
+            tracing::info!("{i} : {state:?}");
+        }
+    }
+
+    #[test]
+    fn test_loop_with_failure() {
+        tracing_subscriber::Registry::default()
+            .with(tracing_forest::ForestLayer::default())
+            .try_init()
+            .unwrap();
+
+        let behavior = Behavior::Loop(vec![
+            Behavior::Action(TestAction::Success),
+            Behavior::Action(TestAction::Failure),
+            Behavior::Action(TestAction::Success),
+        ]);
+        let (mut async_loop, state) = AsyncChild::from_behavior_with_state(behavior);
+
+        let executor = TickedAsyncExecutor::default();
+        let delta_rx = executor.tick_channel();
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        executor
+            .spawn_local("_", async move {
+                cancel_clone
+                    .run_until_cancelled_owned(async {
+                        async_loop.run(delta_rx, &()).await;
+                    })
+                    .await;
+            })
+            .detach();
+
+        for i in 0..6 {
+            executor.tick(0.1, None);
+            tracing::info!("{i} : {state:?}");
+        }
+        cancel.cancel();
+
+        executor.tick(0.1, None);
+        assert_eq!(executor.num_tasks(), 0);
+    }
+}

--- a/async_behaviortree/src/behavior_nodes/loop_node.rs
+++ b/async_behaviortree/src/behavior_nodes/loop_node.rs
@@ -54,10 +54,9 @@ mod tests {
 
     #[test]
     fn test_loop_all_success() {
-        tracing_subscriber::Registry::default()
+        let _ignore = tracing_subscriber::Registry::default()
             .with(tracing_forest::ForestLayer::default())
-            .try_init()
-            .unwrap();
+            .try_init();
 
         let behavior = Behavior::Loop(vec![
             Behavior::Action(TestAction::Success),
@@ -82,10 +81,9 @@ mod tests {
 
     #[test]
     fn test_loop_with_failure() {
-        tracing_subscriber::Registry::default()
+        let _ignore = tracing_subscriber::Registry::default()
             .with(tracing_forest::ForestLayer::default())
-            .try_init()
-            .unwrap();
+            .try_init();
 
         let behavior = Behavior::Loop(vec![
             Behavior::Action(TestAction::Success),

--- a/async_behaviortree/src/behavior_nodes/mod.rs
+++ b/async_behaviortree/src/behavior_nodes/mod.rs
@@ -12,3 +12,6 @@ pub use sequence_node::*;
 
 mod select_node;
 pub use select_node::*;
+
+mod loop_node;
+pub use loop_node::*;

--- a/async_behaviortree/src/behavior_nodes/select_node.rs
+++ b/async_behaviortree/src/behavior_nodes/select_node.rs
@@ -44,7 +44,7 @@ impl<S> AsyncAction<S> for AsyncSelectState<S> {
     }
 
     #[tracing::instrument(level = "trace", name = "Select::reset", skip_all, ret)]
-    fn reset(&mut self, shared: &mut S) {
+    fn reset(&mut self, shared: &S) {
         self.children.iter_mut().for_each(|child| {
             child.reset(shared);
         });

--- a/async_behaviortree/src/behavior_nodes/sequence_node.rs
+++ b/async_behaviortree/src/behavior_nodes/sequence_node.rs
@@ -46,7 +46,7 @@ impl<S> AsyncAction<S> for AsyncSequenceState<S> {
     }
 
     #[tracing::instrument(level = "trace", name = "Sequence::reset", skip_all, ret)]
-    fn reset(&mut self, shared: &mut S) {
+    fn reset(&mut self, shared: &S) {
         self.children
             .iter_mut()
             .for_each(|child| child.reset(shared));

--- a/async_behaviortree/src/behavior_nodes/wait_node.rs
+++ b/async_behaviortree/src/behavior_nodes/wait_node.rs
@@ -37,7 +37,7 @@ impl<S> AsyncAction<S> for AsyncWaitState {
     }
 
     #[tracing::instrument(level = "trace", name = "Wait::reset", skip_all, ret)]
-    fn reset(&mut self, _shared: &mut S) {
+    fn reset(&mut self, _shared: &S) {
         self.elapsed = 0.0;
     }
 

--- a/behaviortree/Cargo.toml
+++ b/behaviortree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "behaviortree"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 
 [dependencies]

--- a/behaviortree/examples/simple_immediate_sync.rs
+++ b/behaviortree/examples/simple_immediate_sync.rs
@@ -141,11 +141,7 @@ fn main() -> Result<(), String> {
 
     let operation_shared = OperationShared::default();
     let blackboard = operation_shared.blackboard.clone();
-    let mut bt = BehaviorTree::new(
-        behavior,
-        behaviortree::BehaviorTreePolicy::RetainOnCompletion,
-        operation_shared,
-    );
+    let mut bt = BehaviorTree::new(behavior, operation_shared);
 
     bt.tick(0.1);
     assert_eq!(bt.status().unwrap(), Status::Running);

--- a/behaviortree/src/behavior_interface.rs
+++ b/behaviortree/src/behavior_interface.rs
@@ -115,8 +115,6 @@ pub mod test_behavior_interface {
         fn into(self) -> ActionType<TestShared> {
             match self {
                 TestAction::Success => {
-                    // let action = Box::new(GenericTestSyncAction::new("Success".into(), true, 1));
-                    // ActionType::Sync()
                     let action = Box::new(GenericTestImmediateAction {
                         name: "Success",
                         status: true,

--- a/behaviortree/src/behavior_nodes/loop_node.rs
+++ b/behaviortree/src/behavior_nodes/loop_node.rs
@@ -22,7 +22,8 @@ impl<S> SyncAction<S> for LoopState<S> {
             }
         }
 
-        self.child.tick(delta, shared)
+        let _child_status = self.child.tick(delta, shared);
+        Status::Running
     }
 
     fn reset(&mut self, shared: &mut S) {

--- a/behaviortree/src/behavior_nodes/loop_node.rs
+++ b/behaviortree/src/behavior_nodes/loop_node.rs
@@ -1,0 +1,34 @@
+use behaviortree_common::Status;
+
+use crate::{SyncAction, child::Child};
+
+pub struct LoopState<S> {
+    child: Child<S>,
+}
+
+impl<S> LoopState<S> {
+    pub fn new(child: Child<S>) -> Self {
+        Self { child }
+    }
+}
+
+impl<S> SyncAction<S> for LoopState<S> {
+    fn tick(&mut self, delta: f64, shared: &mut S) -> Status {
+        let child_status = self.child.status();
+        if let Some(child_status) = child_status {
+            if child_status != Status::Running {
+                self.child.reset(shared);
+            }
+        }
+
+        self.child.tick(delta, shared)
+    }
+
+    fn reset(&mut self, shared: &mut S) {
+        self.child.reset(shared);
+    }
+
+    fn name(&self) -> &'static str {
+        "Loop"
+    }
+}

--- a/behaviortree/src/behavior_nodes/mod.rs
+++ b/behaviortree/src/behavior_nodes/mod.rs
@@ -12,3 +12,6 @@ pub use sequence_node::*;
 
 mod select_node;
 pub use select_node::*;
+
+mod loop_node;
+pub use loop_node::*;

--- a/behaviortree/src/behaviortree.rs
+++ b/behaviortree/src/behaviortree.rs
@@ -12,6 +12,7 @@ pub enum BehaviorTreePolicy {
 pub struct BehaviorTree<S> {
     behavior_policy: BehaviorTreePolicy,
     child: Child<S>,
+    state: State,
     shared: S,
 }
 
@@ -21,10 +22,11 @@ impl<S> BehaviorTree<S> {
         A: Into<ActionType<S>>,
         S: 'static,
     {
-        let child = Child::from_behavior(behavior);
+        let (child, state) = Child::from_behavior_with_state(behavior);
         Self {
             behavior_policy,
             child,
+            state,
             shared,
         }
     }
@@ -52,7 +54,7 @@ impl<S> BehaviorTree<S> {
     }
 
     pub fn state(&self) -> State {
-        self.child.state()
+        self.state.clone()
     }
 
     #[tracing::instrument(level = "trace", name = "BehaviorTree::reset", skip(self))]

--- a/behaviortree/src/behaviortree.rs
+++ b/behaviortree/src/behaviortree.rs
@@ -2,29 +2,20 @@ use behaviortree_common::{Behavior, State, Status};
 
 use crate::{action_type::ActionType, child::Child};
 
-pub enum BehaviorTreePolicy {
-    /// Resets/Reloads the behavior tree once it is completed
-    ReloadOnCompletion,
-    /// On completion, needs manual reset
-    RetainOnCompletion,
-}
-
 pub struct BehaviorTree<S> {
-    behavior_policy: BehaviorTreePolicy,
     child: Child<S>,
     state: State,
     shared: S,
 }
 
 impl<S> BehaviorTree<S> {
-    pub fn new<A>(behavior: Behavior<A>, behavior_policy: BehaviorTreePolicy, shared: S) -> Self
+    pub fn new<A>(behavior: Behavior<A>, shared: S) -> Self
     where
         A: Into<ActionType<S>>,
         S: 'static,
     {
         let (child, state) = Child::from_behavior_with_state(behavior);
         Self {
-            behavior_policy,
             child,
             state,
             shared,
@@ -35,17 +26,7 @@ impl<S> BehaviorTree<S> {
     pub fn tick(&mut self, dt: f64) -> Status {
         if let Some(status) = self.child.status() {
             if status != Status::Running {
-                match self.behavior_policy {
-                    BehaviorTreePolicy::ReloadOnCompletion => {
-                        self.reset();
-                        // Ticks the action below
-                    }
-                    BehaviorTreePolicy::RetainOnCompletion => {
-                        // Do nothing!
-                        // `status` returns the already completed value
-                        return status;
-                    }
-                }
+                return status;
             }
         }
 
@@ -69,27 +50,41 @@ impl<S> BehaviorTree<S> {
 
 #[cfg(test)]
 mod tests {
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
     use super::*;
     use crate::test_behavior_interface::{TestAction, TestShared};
 
     #[test]
     fn behavior_tree_with_reset() {
+        let _ignore = tracing_subscriber::Registry::default()
+            .with(tracing_forest::ForestLayer::default())
+            .try_init();
+
         let behavior = Behavior::Sequence(vec![
             Behavior::Action(TestAction::Success),
             Behavior::Action(TestAction::Success),
         ]);
-        let mut tree =
-            BehaviorTree::new(behavior, BehaviorTreePolicy::RetainOnCompletion, TestShared);
+        let mut tree = BehaviorTree::new(behavior, TestShared);
+        let state = tree.state();
 
         // For unit tests
         let _state = tree.state();
         assert_eq!(tree.status(), None);
+        tracing::info!("State: {state:?}");
 
         let status = tree.tick(0.1);
         assert_eq!(status, Status::Running);
+        tracing::info!("State: {state:?}");
 
         let status = tree.tick(0.1);
         assert_eq!(status, Status::Success);
+        tracing::info!("State: {state:?}");
+
+        // Ticking again returns the same status
+        let status = tree.tick(0.1);
+        assert_eq!(status, Status::Success);
+        tracing::info!("State: {state:?}");
 
         tree.reset();
 
@@ -106,14 +101,14 @@ mod tests {
             Behavior::Action(TestAction::Success),
             Behavior::Action(TestAction::Success),
         ]);
-        let mut tree =
-            BehaviorTree::new(behavior, BehaviorTreePolicy::ReloadOnCompletion, TestShared);
+        let behavior = Behavior::Loop(behavior.into());
+        let mut tree = BehaviorTree::new(behavior, TestShared);
 
         let status = tree.tick(0.1);
         assert_eq!(status, Status::Running);
 
         let status = tree.tick(0.1);
-        assert_eq!(status, Status::Success);
+        assert_eq!(status, Status::Running);
 
         // Automatically resets after success (Reload on Completion)
 
@@ -121,6 +116,6 @@ mod tests {
         assert_eq!(status, Status::Running);
 
         let status = tree.tick(0.1);
-        assert_eq!(status, Status::Success);
+        assert_eq!(status, Status::Running);
     }
 }

--- a/behaviortree/src/child.rs
+++ b/behaviortree/src/child.rs
@@ -87,6 +87,18 @@ impl<S> Child<S> {
 
                 Self::new(action, tx, state)
             }
+            Behavior::Loop(child) => {
+                let child = Child::from_behavior(*child);
+                let child_state = child.state();
+
+                let action = Box::new(LoopState::new(child));
+                let action = ActionType::Sync(action);
+
+                let (tx, rx) = tokio::sync::watch::channel(None);
+                let state = State::SingleChild(action.name(), rx, child_state.into());
+
+                Self::new(action, tx, state)
+            }
         }
     }
 

--- a/behaviortree_common/src/behavior.rs
+++ b/behaviortree_common/src/behavior.rs
@@ -26,9 +26,8 @@ pub enum Behavior<A> {
     /// Fails if the last behavior fails.
     /// Can be thought of as a short-circuited logical OR gate.
     Select(Vec<Behavior<A>>),
-    /// Runs behaviors in a loop one by one
+    /// Runs behavior in a loop
     ///
-    /// If any behavior fails, reset and restart the loop from the beginning
-    /// If all the behaviors succeed, reset and restart the loop from the beginning
-    Loop(Vec<Behavior<A>>),
+    /// If behavior fails / suceeds, reset and restart the behavior
+    Loop(Box<Behavior<A>>),
 }

--- a/behaviortree_common/src/behavior.rs
+++ b/behaviortree_common/src/behavior.rs
@@ -26,4 +26,9 @@ pub enum Behavior<A> {
     /// Fails if the last behavior fails.
     /// Can be thought of as a short-circuited logical OR gate.
     Select(Vec<Behavior<A>>),
+    /// Runs behaviors in a loop one by one
+    ///
+    /// If any behavior fails, reset and restart the loop from the beginning
+    /// If all the behaviors succeed, reset and restart the loop from the beginning
+    Loop(Vec<Behavior<A>>),
 }


### PR DESCRIPTION
# Main

- Added `Loop` behavior
- Async BehaviorTree traits take `&S` instead of `&mut S`

# Misc

- Removed State from Child and AsyncChild
- Updated BehaviorTree and AsyncBehaviorTree implementation