### PR TITLE
BehaviorTree Future: Handler

### DIFF
--- a/behaviortree_future/examples/simple.rs
+++ b/behaviortree_future/examples/simple.rs
@@ -1,8 +1,8 @@
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use behaviortree_future::{
-    AsyncActionContext, AsyncBehaviorTree, Behavior, BehaviorTreeAsyncAction, BehaviorTreeObserver,
-    Status,
+    AsyncActionContext, AsyncBehaviorTree, Behavior, BehaviorTreeAsyncAction,
+    BehaviorTreeAsyncHandler, BehaviorTreeObserver, Status,
 };
 use ticked_async_executor::TickedAsyncExecutor;
 use tokio_util::sync::CancellationToken;
@@ -37,7 +37,7 @@ impl Action {
 
         yield_now().await;
         yield_now().await;
-        yield_now().await;
+        // yield_now().await;
 
         memory.run(|mut s| {
             println!("SUM: {sum}");
@@ -48,43 +48,19 @@ impl Action {
 }
 
 impl BehaviorTreeAsyncAction<ActionRunner> for Action {
-    fn create_future(
-        &self,
-        ctx: AsyncActionContext<ActionRunner>,
-    ) -> reusable_box_future::ReusableLocalBoxFuture<bool> {
+    fn make_future<'a, H>(&self, ctx: AsyncActionContext<ActionRunner>, handler: H) -> H::Output
+    where
+        H: BehaviorTreeAsyncHandler<'a>,
+    {
         match *self {
-            Action::Add { i1, i2, o } => {
-                reusable_box_future::ReusableLocalBoxFuture::new(Self::add(i1, i2, o, ctx))
-            }
-            Action::Sub => reusable_box_future::ReusableLocalBoxFuture::new(async move { true }),
-            Action::Mul => reusable_box_future::ReusableLocalBoxFuture::new(async move { true }),
-            Action::Div => reusable_box_future::ReusableLocalBoxFuture::new(async move { true }),
+            Action::Add { i1, i2, o } => handler.future(Self::add(i1, i2, o, ctx)),
+            Action::Sub => handler.future(async move { true }),
+            Action::Mul => handler.future(async move { true }),
+            Action::Div => handler.future(async move { true }),
         }
     }
 
-    fn reset_future(
-        &self,
-        ctx: AsyncActionContext<ActionRunner>,
-        future: &mut reusable_box_future::ReusableLocalBoxFuture<bool>,
-    ) {
-        match *self {
-            Action::Add { i1, i2, o } => {
-                future
-                    .try_set(Self::add(i1, i2, o, ctx))
-                    .map_err(|_| {})
-                    .unwrap();
-            }
-            Action::Sub => {
-                future.set(async move { true });
-            }
-            Action::Mul => {
-                future.set(async move { true });
-            }
-            Action::Div => {
-                future.set(async move { true });
-            }
-        }
-    }
+    fn reset(&self, ctx: AsyncActionContext<ActionRunner>) {}
 }
 
 #[derive(Clone)]

--- a/behaviortree_future/src/async_behavior_tree.rs
+++ b/behaviortree_future/src/async_behavior_tree.rs
@@ -28,7 +28,7 @@ impl AsyncBehaviorTreeController {
         self.control.replace(Control::Reset);
     }
 
-    pub fn shutdown(self) {
+    pub fn shutdown(&self) {
         self.control.replace(Control::Shutdown);
     }
 }

--- a/behaviortree_future/src/async_behavior_tree.rs
+++ b/behaviortree_future/src/async_behavior_tree.rs
@@ -18,6 +18,7 @@ enum Control {
     Shutdown,
 }
 
+#[derive(Clone)]
 pub struct AsyncBehaviorTreeController {
     control: Rc<Cell<Control>>,
 }

--- a/behaviortree_future/src/async_interface.rs
+++ b/behaviortree_future/src/async_interface.rs
@@ -91,17 +91,17 @@ pub(crate) trait BehaviorTreeReset<R> {
     fn reset(&mut self, ctx: AsyncActionContext<R>);
 }
 
-pub trait BehaviorTreeAsyncAction<R> {
-    fn create_future(
-        &self,
-        ctx: AsyncActionContext<R>,
-    ) -> reusable_box_future::ReusableLocalBoxFuture<bool>;
+pub trait BehaviorTreeAsyncHandler<'a> {
+    type Output;
+    fn future(self, future: impl std::future::Future<Output = bool> + 'a) -> Self::Output;
+}
 
-    fn reset_future(
-        &self,
-        ctx: AsyncActionContext<R>,
-        future: &mut reusable_box_future::ReusableLocalBoxFuture<bool>,
-    );
+pub trait BehaviorTreeAsyncAction<R> {
+    fn make_future<'a, H>(&self, ctx: AsyncActionContext<R>, handler: H) -> H::Output
+    where
+        H: BehaviorTreeAsyncHandler<'a>;
+
+    fn reset(&self, ctx: AsyncActionContext<R>);
 }
 
 pub trait BehaviorTreeObserver<A> {

--- a/behaviortree_future/src/behavior_nodes/async_action.rs
+++ b/behaviortree_future/src/behavior_nodes/async_action.rs
@@ -1,4 +1,24 @@
-use crate::{AsyncActionContext, BehaviorTreeAsyncAction, BehaviorTreeReset};
+use reusable_box_future::ReusableLocalBoxFuture;
+
+use crate::{
+    AsyncActionContext, BehaviorTreeAsyncAction, BehaviorTreeAsyncHandler, BehaviorTreeReset,
+};
+
+struct CreateReusableLocalBoxFutureHandler;
+impl BehaviorTreeAsyncHandler<'static> for CreateReusableLocalBoxFutureHandler {
+    type Output = ReusableLocalBoxFuture<bool>;
+    fn future(self, future: impl std::future::Future<Output = bool> + 'static) -> Self::Output {
+        reusable_box_future::ReusableLocalBoxFuture::new(future)
+    }
+}
+
+struct UpdateReusableLocalBoxFutureHandler<'a>(&'a mut ReusableLocalBoxFuture<bool>);
+impl<'a> BehaviorTreeAsyncHandler<'static> for UpdateReusableLocalBoxFutureHandler<'a> {
+    type Output = ();
+    fn future(self, future: impl std::future::Future<Output = bool> + 'static) -> Self::Output {
+        self.0.set(future);
+    }
+}
 
 #[pin_project::pin_project]
 pub struct AsyncAction<A> {
@@ -13,7 +33,7 @@ impl<A> AsyncAction<A> {
     where
         A: BehaviorTreeAsyncAction<R>,
     {
-        let future = action.create_future(ctx);
+        let future = action.make_future(ctx, CreateReusableLocalBoxFutureHandler);
         Self { action, future }
     }
 }
@@ -23,7 +43,9 @@ where
     A: BehaviorTreeAsyncAction<R>,
 {
     fn reset(&mut self, ctx: AsyncActionContext<R>) {
-        self.action.reset_future(ctx, &mut self.future);
+        self.action.reset(ctx);
+        self.action
+            .make_future(ctx, UpdateReusableLocalBoxFutureHandler(&mut self.future));
     }
 }
 

--- a/behaviortree_future/src/test_nodes/test_operation.rs
+++ b/behaviortree_future/src/test_nodes/test_operation.rs
@@ -1,4 +1,4 @@
-use crate::{AsyncActionContext, BehaviorTreeAsyncAction};
+use crate::{AsyncActionContext, BehaviorTreeAsyncAction, BehaviorTreeAsyncHandler};
 
 #[derive(Debug, Clone)]
 pub enum TestOperation {
@@ -52,53 +52,26 @@ impl TestOperation {
 }
 
 impl BehaviorTreeAsyncAction<TestOperationRunner> for TestOperation {
-    fn create_future(
+    fn make_future<'a, H>(
         &self,
         ctx: AsyncActionContext<TestOperationRunner>,
-    ) -> reusable_box_future::ReusableLocalBoxFuture<bool> {
+        handler: H,
+    ) -> H::Output
+    where
+        H: BehaviorTreeAsyncHandler<'a>,
+    {
         match *self {
             TestOperation::Add(a, b, retval, times) => {
-                reusable_box_future::ReusableLocalBoxFuture::new(TestOperation::this_add(
-                    a, b, retval, times, ctx,
-                ))
+                handler.future(Self::this_add(a, b, retval, times, ctx))
             }
-            TestOperation::Yield(retval) => {
-                reusable_box_future::ReusableLocalBoxFuture::new(Self::this_yield(retval))
-            }
+            TestOperation::Yield(retval) => handler.future(Self::this_yield(retval)),
             TestOperation::ConsumeDelta(retval) => {
-                reusable_box_future::ReusableLocalBoxFuture::new(TestOperation::this_consume_delta(
-                    retval, ctx,
-                ))
+                handler.future(Self::this_consume_delta(retval, ctx))
             }
         }
     }
 
-    fn reset_future(
-        &self,
-        ctx: AsyncActionContext<TestOperationRunner>,
-        future: &mut reusable_box_future::ReusableLocalBoxFuture<bool>,
-    ) {
-        match *self {
-            TestOperation::Add(a, b, retval, times) => {
-                future
-                    .try_set(Self::this_add(a, b, retval, times, ctx))
-                    .map_err(|_| {})
-                    .unwrap();
-            }
-            TestOperation::Yield(retval) => {
-                future
-                    .try_set(Self::this_yield(retval))
-                    .map_err(|_| {})
-                    .unwrap();
-            }
-            TestOperation::ConsumeDelta(retval) => {
-                future
-                    .try_set(Self::this_consume_delta(retval, ctx))
-                    .map_err(|_| {})
-                    .unwrap();
-            }
-        }
-    }
+    fn reset(&self, ctx: AsyncActionContext<TestOperationRunner>) {}
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
# Main
- Add `BehaviorTreeAsyncHandler` so that code doesn't need to be replicated using reusable-box-future
- Added `reset` API to `BehaviorTreeAsyncAction`

# Misc
- Make `AsyncBehaviorTreeController` Clone