### PR TITLE
BehaviorTree Future: Subtree

### DIFF
--- a/behaviortree_future/benches/pointer_benchmark.rs
+++ b/behaviortree_future/benches/pointer_benchmark.rs
@@ -12,7 +12,7 @@ pub struct TestRefCell<R> {
 impl<R> TestRefCell<R> {
     pub fn get(&self) {}
 
-    pub fn get_mut<O>(&mut self, mut cb: impl FnMut(&mut Inner<R>) -> O) -> O {
+    pub fn get_mut<O>(&mut self, cb: impl FnOnce(&mut Inner<R>) -> O) -> O {
         let mut r = self.inner.borrow_mut();
         cb(&mut *r)
     }
@@ -23,7 +23,7 @@ pub struct TestUnsafeCell<R> {
 }
 
 impl<R> TestUnsafeCell<R> {
-    pub fn get_mut<O>(&mut self, mut cb: impl FnMut(&mut Inner<R>) -> O) -> O {
+    pub fn get_mut<O>(&mut self, cb: impl FnOnce(&mut Inner<R>) -> O) -> O {
         let r = unsafe { &mut *(self.inner.get()) };
         cb(r)
     }
@@ -34,7 +34,7 @@ pub struct TestPointer<R> {
 }
 
 impl<R> TestPointer<R> {
-    pub fn get_mut<O>(&mut self, mut cb: impl FnMut(&mut Inner<R>) -> O) -> O {
+    pub fn get_mut<O>(&mut self, cb: impl FnOnce(&mut Inner<R>) -> O) -> O {
         let r = unsafe { &mut *self.inner };
         cb(r)
     }

--- a/behaviortree_future/src/async_behavior_state.rs
+++ b/behaviortree_future/src/async_behavior_state.rs
@@ -1,6 +1,8 @@
 use crate::{
     AsyncActionContext, Behavior, BehaviorTreeAsyncAction, BehaviorTreeReset,
-    behavior_nodes::{AsyncAction, AsyncInvert, AsyncLoop, AsyncSelect, AsyncSequence, AsyncTimes},
+    behavior_nodes::{
+        AsyncAction, AsyncInvert, AsyncLoop, AsyncSelect, AsyncSequence, AsyncSubtree, AsyncTimes,
+    },
 };
 
 #[pin_project::pin_project(project = AsyncBehaviorStateProj)]
@@ -11,6 +13,7 @@ pub enum AsyncBehaviorState<A, R> {
     Select(#[pin] AsyncSelect<AsyncBehaviorState<A, R>, R>),
     Loop(#[pin] AsyncLoop<AsyncBehaviorState<A, R>, R>),
     Times(#[pin] AsyncTimes<AsyncBehaviorState<A, R>, R>),
+    Subtree(#[pin] AsyncSubtree<AsyncBehaviorState<A, R>>),
 }
 
 impl<A, R> AsyncBehaviorState<A, R> {
@@ -42,6 +45,10 @@ impl<A, R> AsyncBehaviorState<A, R> {
                 let child = Self::from_behavior(*behavior, ctx);
                 Self::Loop(AsyncLoop::new(child, ctx))
             }
+            Behavior::Subtree(_name, behavior) => {
+                let child = Self::from_behavior(*behavior, ctx);
+                Self::Subtree(AsyncSubtree::new(child))
+            }
         }
     }
 }
@@ -58,6 +65,7 @@ where
             AsyncBehaviorState::Select(a) => a,
             AsyncBehaviorState::Loop(a) => a,
             AsyncBehaviorState::Times(a) => a,
+            AsyncBehaviorState::Subtree(a) => a,
         };
         r.reset(ctx);
     }
@@ -80,6 +88,7 @@ where
             AsyncBehaviorStateProj::Select(f) => f,
             AsyncBehaviorStateProj::Loop(f) => f,
             AsyncBehaviorStateProj::Times(f) => f,
+            AsyncBehaviorStateProj::Subtree(f) => f,
         };
         future.poll(cx)
     }

--- a/behaviortree_future/src/async_behavior_state_with_observer.rs
+++ b/behaviortree_future/src/async_behavior_state_with_observer.rs
@@ -3,7 +3,9 @@ use std::rc::Rc;
 use crate::{
     AsyncActionContext, Behavior, BehaviorTreeAsyncAction, BehaviorTreeObserver, BehaviorTreeReset,
     Status,
-    behavior_nodes::{AsyncAction, AsyncInvert, AsyncLoop, AsyncSelect, AsyncSequence, AsyncTimes},
+    behavior_nodes::{
+        AsyncAction, AsyncInvert, AsyncLoop, AsyncSelect, AsyncSequence, AsyncSubtree, AsyncTimes,
+    },
 };
 
 #[derive(Debug, Clone)]
@@ -14,6 +16,7 @@ pub enum AsyncBehaviorStateTree {
     Select(usize, Rc<[AsyncBehaviorStateTree]>),
     Loop(usize, Rc<AsyncBehaviorStateTree>),
     Times(usize, Rc<AsyncBehaviorStateTree>),
+    Subtree(Rc<String>, usize, Rc<AsyncBehaviorStateTree>),
 }
 
 #[pin_project::pin_project(project = AsyncBehaviorStateWithObserverProj)]
@@ -37,6 +40,10 @@ pub enum AsyncBehaviorStateWithObserver<A, R, O> {
     ),
     Times(
         #[pin] AsyncTimes<AsyncBehaviorStateWithObserver<A, R, O>, R>,
+        (Rc<O>, usize),
+    ),
+    Subtree(
+        #[pin] AsyncSubtree<AsyncBehaviorStateWithObserver<A, R, O>>,
         (Rc<O>, usize),
     ),
 }
@@ -103,6 +110,17 @@ impl<A, R, O> AsyncBehaviorStateWithObserver<A, R, O> {
                 let state = Self::Loop(AsyncLoop::new(child_state, ctx), parent_o);
                 (state, state_tree)
             }
+            Behavior::Subtree(name, behavior) => {
+                let (child_state, child_state_tree) =
+                    Self::from_behavior(*behavior, ctx, observer, id);
+                let state_tree = AsyncBehaviorStateTree::Subtree(
+                    name.into(),
+                    parent_o.1,
+                    child_state_tree.into(),
+                );
+                let state = Self::Subtree(AsyncSubtree::new(child_state), parent_o);
+                (state, state_tree)
+            }
         }
     }
 }
@@ -120,6 +138,7 @@ where
             AsyncBehaviorStateWithObserver::Select(a, o) => (a, o),
             AsyncBehaviorStateWithObserver::Loop(a, o) => (a, o),
             AsyncBehaviorStateWithObserver::Times(a, o) => (a, o),
+            AsyncBehaviorStateWithObserver::Subtree(a, o) => (a, o),
         };
         r.reset(ctx);
         observer.0.update(observer.1, None);
@@ -147,6 +166,7 @@ where
             AsyncBehaviorStateWithObserverProj::Select(f, o) => (f, o),
             AsyncBehaviorStateWithObserverProj::Loop(f, o) => (f, o),
             AsyncBehaviorStateWithObserverProj::Times(f, o) => (f, o),
+            AsyncBehaviorStateWithObserverProj::Subtree(f, o) => (f, o),
         };
         let poll_status = future.poll(cx);
         let status = Status::from(poll_status);

--- a/behaviortree_future/src/async_interface.rs
+++ b/behaviortree_future/src/async_interface.rs
@@ -60,12 +60,12 @@ impl<R> AsyncActionContext<R> {
         self.safe_ctx_ref_mut().consume_delta()
     }
 
-    pub fn runner_ref<Ret>(&self, mut cb: impl FnMut(&R) -> Ret) -> Ret {
+    pub fn runner_ref<Ret>(&self, cb: impl FnOnce(&R) -> Ret) -> Ret {
         let r = &self.safe_ctx_ref().runner;
         cb(r)
     }
 
-    pub fn runner_ref_mut<Ret>(&mut self, mut cb: impl FnMut(&mut R) -> Ret) -> Ret {
+    pub fn runner_ref_mut<Ret>(&mut self, cb: impl FnOnce(&mut R) -> Ret) -> Ret {
         let r = &mut self.safe_ctx_ref_mut().runner;
         cb(r)
     }

--- a/behaviortree_future/src/async_interface.rs
+++ b/behaviortree_future/src/async_interface.rs
@@ -18,14 +18,6 @@ pub(crate) struct AsyncActionContextOwned<R> {
     ctx: std::rc::Rc<std::cell::UnsafeCell<AsyncActionContextInner<R>>>,
 }
 
-impl<R> Clone for AsyncActionContextOwned<R> {
-    fn clone(&self) -> Self {
-        Self {
-            ctx: self.ctx.clone(),
-        }
-    }
-}
-
 impl<R> AsyncActionContextOwned<R> {
     pub fn new(runner: R, delta: f64) -> Self {
         let ctx = std::rc::Rc::new(std::cell::UnsafeCell::new(AsyncActionContextInner {

--- a/behaviortree_future/src/behavior.rs
+++ b/behaviortree_future/src/behavior.rs
@@ -26,4 +26,7 @@ pub enum Behavior<A> {
     ///
     /// Reset and restart the behavior once it has completed irrespective of success or failure
     Loop(Box<Behavior<A>>),
+
+    ///
+    Subtree(String, Box<Behavior<A>>),
 }

--- a/behaviortree_future/src/behavior_nodes/async_subtree.rs
+++ b/behaviortree_future/src/behavior_nodes/async_subtree.rs
@@ -1,0 +1,37 @@
+use crate::{AsyncActionContext, BehaviorTreeReset};
+
+pub struct AsyncSubtree<C> {
+    child: Box<C>,
+}
+
+impl<C> AsyncSubtree<C> {
+    pub fn new(child: C) -> Self {
+        Self {
+            child: child.into(),
+        }
+    }
+}
+
+impl<C, R> BehaviorTreeReset<R> for AsyncSubtree<C>
+where
+    C: BehaviorTreeReset<R>,
+{
+    fn reset(&mut self, ctx: AsyncActionContext<R>) {
+        self.child.reset(ctx);
+    }
+}
+
+impl<C> std::future::Future for AsyncSubtree<C>
+where
+    C: std::future::Future<Output = bool> + Unpin,
+{
+    type Output = C::Output;
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let bt = self.as_mut().get_mut();
+        let child = std::pin::Pin::new(&mut bt.child);
+        child.poll(cx)
+    }
+}

--- a/behaviortree_future/src/behavior_nodes/mod.rs
+++ b/behaviortree_future/src/behavior_nodes/mod.rs
@@ -12,3 +12,6 @@ pub use async_loop::*;
 
 mod async_times;
 pub use async_times::*;
+
+mod async_subtree;
+pub use async_subtree::*;


### PR DESCRIPTION
# Main
- Subtree implementation: Custom behavior can be given a specific name

# Misc
- `runner_ref` and `runner_ref_mut` use FnOnce instead of FnMut
- Remove clone from AsyncActionContextOwned